### PR TITLE
Fix macOS Build

### DIFF
--- a/include/altacore/ast/attribute-node.hpp
+++ b/include/altacore/ast/attribute-node.hpp
@@ -1,16 +1,7 @@
 #ifndef ALTACORE_AST_ATTRIBUTE_NODE_HPP
 #define ALTACORE_AST_ATTRIBUTE_NODE_HPP
 
-#if defined(__has_include) && __has_include(<optional>)
-#include <optional>
-#define ALTACORE_OPTIONAL std::optional
-#define ALTACORE_NULLOPT std::nullopt
-#else
-#include <optional.hpp>
-#define ALTACORE_OPTIONAL tl::optional
-#define ALTACORE_NULLOPT tl::nullopt
-#endif
-
+#include "../optional.hpp"
 #include "node.hpp"
 #include <vector>
 #include <string>

--- a/include/altacore/ast/class-instantiation-expression.hpp
+++ b/include/altacore/ast/class-instantiation-expression.hpp
@@ -4,7 +4,7 @@
 #include "expression-node.hpp"
 #include "../det/class.hpp"
 #include <string>
-#include <unordered_map>
+#include "../simple-map.hpp"
 #include "../variant.hpp"
 
 namespace AltaCore {

--- a/include/altacore/ast/function-call-expression.hpp
+++ b/include/altacore/ast/function-call-expression.hpp
@@ -4,7 +4,7 @@
 #include "expression-node.hpp"
 #include "../det/scope-item.hpp"
 #include "../det/type.hpp"
-#include <unordered_map>
+#include "../simple-map.hpp"
 #include "../variant.hpp"
 #include "../det/function.hpp"
 
@@ -20,7 +20,7 @@ namespace AltaCore {
         FunctionCallExpression() {};
         FunctionCallExpression(std::shared_ptr<ExpressionNode> target, std::vector<std::pair<std::string, std::shared_ptr<ExpressionNode>>> arguments = {});
 
-        static std::tuple<size_t, std::unordered_map<size_t, size_t>, std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>>> findCompatibleCall(std::vector<std::tuple<std::string, std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>> arguments, std::vector<std::shared_ptr<DET::Type>> funcTypes);
+        static std::tuple<size_t, ALTACORE_MAP<size_t, size_t>, std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>>> findCompatibleCall(std::vector<std::tuple<std::string, std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>> arguments, std::vector<std::shared_ptr<DET::Type>> funcTypes);
 
         ALTACORE_AST_DETAIL(FunctionCallExpression);
         ALTACORE_AST_VALIDATE;

--- a/include/altacore/attributes.hpp
+++ b/include/altacore/attributes.hpp
@@ -1,19 +1,10 @@
 #ifndef ALTACORE_ATTRIBUTES_HPP
 #define ALTACORE_ATTRIBUTES_HPP
 
-#if defined(__has_include) && __has_include(<optional>)
-#include <optional>
-#define ALTACORE_OPTIONAL std::optional
-#define ALTACORE_NULLOPT std::nullopt
-#else
-#include <optional.hpp>
-#define ALTACORE_OPTIONAL tl::optional
-#define ALTACORE_NULLOPT tl::nullopt
-#endif
-
+#include "simple-map.hpp"
+#include "optional.hpp"
 #include <vector>
 #include <string>
-#include <map>
 #include <functional>
 #include "ast-shared.hpp"
 
@@ -58,7 +49,7 @@ namespace AltaCore {
     };
 
     extern std::vector<Attribute> registeredGlobalAttributes;
-    extern std::map<std::string, std::vector<Attribute>> registeredFileAttributes;
+    extern ALTACORE_MAP<std::string, std::vector<Attribute>> registeredFileAttributes;
 
     bool registerAttribute(std::vector<std::string> fullDomainPath, std::vector<AST::NodeType> appliesTo = {}, std::function<void(std::shared_ptr<AST::Node>, std::shared_ptr<DH::Node>, std::vector<AttributeArgument>)> callback = nullptr, std::string file = "");
     ALTACORE_OPTIONAL<Attribute> findAttribute(std::vector<std::string> fullDomainPath, ALTACORE_OPTIONAL<AST::NodeType> appliesTo = ALTACORE_NULLOPT, std::string file = "");

--- a/include/altacore/detail-handles.hpp
+++ b/include/altacore/detail-handles.hpp
@@ -1,16 +1,8 @@
 #ifndef ALTACORE_DETAIL_HANDLES_HPP
 #define ALTACORE_DETAIL_HANDLES_HPP
 
-#if defined(__has_include) && __has_include(<optional>)
-#include <optional>
-#define ALTACORE_OPTIONAL std::optional
-#define ALTACORE_NULLOPT std::nullopt
-#else
-#include <optional.hpp>
-#define ALTACORE_OPTIONAL tl::optional
-#define ALTACORE_NULLOPT tl::nullopt
-#endif
-
+#include "simple-map.hpp"
+#include "optional.hpp"
 #include "det.hpp"
 #include "variant.hpp"
 #include "attributes.hpp"
@@ -94,7 +86,7 @@ namespace AltaCore {
       std::shared_ptr<ExpressionNode> target = nullptr;
 
       bool accessesNamespace = false;
-      std::unordered_map<size_t, std::vector<std::shared_ptr<DET::Class>>> parentClassAccessors;
+      ALTACORE_MAP<size_t, std::vector<std::shared_ptr<DET::Class>>> parentClassAccessors;
       std::shared_ptr<DET::Function> readAccessor = nullptr;
       size_t readAccessorIndex = 0;
       std::shared_ptr<DET::Function> writeAccessor = nullptr;
@@ -171,7 +163,7 @@ namespace AltaCore {
       bool superclass = false;
       std::shared_ptr<DET::Function> constructor = nullptr;
       std::shared_ptr<DET::Class> klass = nullptr;
-      std::unordered_map<size_t, size_t> argumentMap;
+      ALTACORE_MAP<size_t, size_t> argumentMap;
       std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<AST::ExpressionNode>, std::shared_ptr<ExpressionNode>>, std::vector<std::pair<std::shared_ptr<AST::ExpressionNode>, std::shared_ptr<ExpressionNode>>>>> adjustedArguments;
     };
     class ClassMemberDefinitionStatement: public ClassStatementNode {
@@ -249,7 +241,7 @@ namespace AltaCore {
       std::shared_ptr<AST::ExpressionNode> methodClassTarget = nullptr;
       std::shared_ptr<ExpressionNode> methodClassTargetInfo = nullptr;
       std::shared_ptr<DET::Type> targetType = nullptr;
-      std::unordered_map<size_t, size_t> argumentMap;
+      ALTACORE_MAP<size_t, size_t> argumentMap;
       std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<AST::ExpressionNode>, std::shared_ptr<ExpressionNode>>, std::vector<std::pair<std::shared_ptr<AST::ExpressionNode>, std::shared_ptr<ExpressionNode>>>>> adjustedArguments;
     };
     class FunctionDeclarationNode: public StatementNode {
@@ -357,7 +349,7 @@ namespace AltaCore {
       std::shared_ptr<DET::Class> superclass = nullptr;
       /*
       std::shared_ptr<DET::Function> constructor = nullptr;
-      std::unordered_map<size_t, size_t> argumentMap;
+      ALTACORE_MAP<size_t, size_t> argumentMap;
       std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<AST::ExpressionNode>, std::shared_ptr<ExpressionNode>>, std::vector<std::pair<std::shared_ptr<AST::ExpressionNode>, std::shared_ptr<ExpressionNode>>>>> adjustedArguments;
       */
     };

--- a/include/altacore/lexer.hpp
+++ b/include/altacore/lexer.hpp
@@ -1,12 +1,12 @@
 #ifndef ALTACORE_LEXER_HPP
 #define ALTACORE_LEXER_HPP
 
+#include "simple-map.hpp"
 #include <stdexcept>
 #include <string>
 #include <vector>
 #include <tuple>
 #include <deque>
-#include <unordered_map>
 #include <unordered_set>
 #include <functional>
 #include <utility>
@@ -171,7 +171,7 @@ namespace AltaCore {
     class Lexer {
       private:
         std::deque<char> backlog;
-        std::unordered_map<size_t, std::unordered_set<TokenType>> fails;
+        ALTACORE_MAP<size_t, std::unordered_set<TokenType>> fails;
         TokenType hangingRule = TokenType::None;
         size_t ruleIteration = 0;
         bool consumeNext = false;

--- a/include/altacore/optional.hpp
+++ b/include/altacore/optional.hpp
@@ -5,10 +5,12 @@
 #include <optional>
 #define ALTACORE_OPTIONAL std::optional
 #define ALTACORE_NULLOPT std::nullopt
+#define ALTACORE_MAKE_OPTIONAL std::make_optional
 #else
 #include <optional.hpp>
 #define ALTACORE_OPTIONAL tl::optional
 #define ALTACORE_NULLOPT tl::nullopt
+#define ALTACORE_MAKE_OPTIONAL tl::make_optional
 #endif
 
 #endif /* ALTACORE_OPTIONAL_HPP */

--- a/include/altacore/optional.hpp
+++ b/include/altacore/optional.hpp
@@ -1,0 +1,14 @@
+#ifndef ALTACORE_OPTIONAL_HPP
+#define ALTACORE_OPTIONAL_HPP
+
+#if defined(__has_include) && __has_include(<optional>)
+#include <optional>
+#define ALTACORE_OPTIONAL std::optional
+#define ALTACORE_NULLOPT std::nullopt
+#else
+#include <optional.hpp>
+#define ALTACORE_OPTIONAL tl::optional
+#define ALTACORE_NULLOPT tl::nullopt
+#endif
+
+#endif /* ALTACORE_OPTIONAL_HPP */

--- a/include/altacore/parser.hpp
+++ b/include/altacore/parser.hpp
@@ -1,19 +1,10 @@
 #ifndef ALTACORE_PARSER_HPP
 #define ALTACORE_PARSER_HPP
 
-#if defined(__has_include) && __has_include(<optional>)
-#include <optional>
-#define ALTACORE_OPTIONAL std::optional
-#define ALTACORE_NULLOPT std::nullopt
-#else
-#include <optional.hpp>
-#define ALTACORE_OPTIONAL tl::optional
-#define ALTACORE_NULLOPT tl::nullopt
-#endif
-
+#include "optional.hpp"
 #include "variant.hpp"
 #include "any.hpp"
-#include <unordered_map>
+#include "simple-map.hpp"
 #include <unordered_set>
 #include <vector>
 #include <functional>

--- a/include/altacore/preprocessor.hpp
+++ b/include/altacore/preprocessor.hpp
@@ -1,10 +1,9 @@
 #ifndef ALTACORE_PREPROCESSOR_HPP
 #define ALTACORE_PREPROCESSOR_HPP
 
+#include "simple-map.hpp"
 #include <string>
 #include <functional>
-#include <map>
-#include <unordered_map>
 #include <stack>
 #include "fs.hpp"
 #include "parser.hpp"
@@ -72,7 +71,7 @@ namespace AltaCore {
     };
     class ExpressionParser: public Parser::GenericParser<RuleType, Lexer::TokenType, Expression> {
       protected:
-        std::map<std::string, Expression>& definitions;
+        ALTACORE_MAP<std::string, Expression>& definitions;
         bool evaluateExpressions = true; // for short-circuit evaluation in && and ||
 
         // <builtin-macros>
@@ -81,7 +80,7 @@ namespace AltaCore {
       public:
         void parse();
 
-        ExpressionParser(std::vector<Lexer::Token> tokens, std::map<std::string, Expression>& definitions);
+        ExpressionParser(std::vector<Lexer::Token> tokens, ALTACORE_MAP<std::string, Expression>& definitions);
     };
 
     struct Location {
@@ -120,17 +119,17 @@ namespace AltaCore {
         bool canSaveForLater = true;
       public:
         Filesystem::Path filePath;
-        std::map<std::string, Expression>& definitions;
-        std::map<std::string, std::string>& fileResults;
-        std::unordered_map<std::string, std::vector<Location>>& locationMaps;
+        ALTACORE_MAP<std::string, Expression>& definitions;
+        ALTACORE_MAP<std::string, std::string>& fileResults;
+        ALTACORE_MAP<std::string, std::vector<Location>>& locationMaps;
         void feed(std::string chunk);
         void done();
 
         Preprocessor(
           Filesystem::Path _filePath,
-          std::map<std::string, Expression>& _defs,
-          std::map<std::string, std::string>& _results,
-          std::unordered_map<std::string, std::vector<Location>>& _locationMaps,
+          ALTACORE_MAP<std::string, Expression>& _defs,
+          ALTACORE_MAP<std::string, std::string>& _results,
+          ALTACORE_MAP<std::string, std::vector<Location>>& _locationMaps,
           std::function<Filesystem::Path(Preprocessor&, std::string)> _fileResolver = defaultFileResolver,
           std::function<void(Preprocessor&, Preprocessor&, Filesystem::Path)> _fileReader = defaultFileReader
         ):

--- a/include/altacore/simple-map.hpp
+++ b/include/altacore/simple-map.hpp
@@ -1,0 +1,12 @@
+#ifndef ALTACORE_SIMPLE_MAP_HPP
+#define ALTACORE_SIMPLE_MAP_HPP
+
+#if defined(__has_include) && __has_include(<unordered_map>)
+#include <unordered_map>
+#define ALTACORE_MAP std::unordered_map
+#else
+#include <map>
+#define ALTACORE_MAP std::map
+#endif
+
+#endif /* ALTACORE_SIMPLE_MAP_HPP */

--- a/src/ast/attribute-node.cpp
+++ b/src/ast/attribute-node.cpp
@@ -57,7 +57,7 @@ void AltaCore::AST::AttributeNode::run(std::shared_ptr<DH::AttributeNode> info, 
 void AltaCore::AST::AttributeNode::findAttribute(std::shared_ptr<DH::AttributeNode> info) {
   info->attribute = Attributes::findAttribute(
     accessors,
-    info->target ? std::make_optional(info->target->nodeType()) : ALTACORE_NULLOPT,
+    info->target ? ALTACORE_MAKE_OPTIONAL(info->target->nodeType()) : ALTACORE_NULLOPT,
     info->module.lock()->path.toString()
   );
 };

--- a/src/ast/class-instantiation-expression.cpp
+++ b/src/ast/class-instantiation-expression.cpp
@@ -34,7 +34,7 @@ ALTACORE_AST_DETAIL_D(ClassInstantiationExpression) {
   }
 
   std::vector<std::shared_ptr<DET::Type>> targetTypes;
-  std::unordered_map<size_t, size_t> indexMap;
+  ALTACORE_MAP<size_t, size_t> indexMap;
   for (size_t i = 0; i < info->klass->constructors.size(); i++) {
     auto& constr = info->klass->constructors[i];
     if (!scope->canSee(constr)) {

--- a/src/ast/class-instantiation-expression.cpp
+++ b/src/ast/class-instantiation-expression.cpp
@@ -3,6 +3,7 @@
 #include "../../include/altacore/ast/accessor.hpp"
 #include "../../include/altacore/det/function.hpp"
 #include "../../include/altacore/ast/function-call-expression.hpp"
+#include "../../include/altacore/simple-map.hpp"
 
 const AltaCore::AST::NodeType AltaCore::AST::ClassInstantiationExpression::nodeType() {
   return NodeType::ClassInstantiationExpression;

--- a/src/ast/function-call-expression.cpp
+++ b/src/ast/function-call-expression.cpp
@@ -2,7 +2,7 @@
 #include "../../include/altacore/det/type.hpp"
 #include "../../include/altacore/ast/fetch.hpp"
 #include "../../include/altacore/ast/accessor.hpp"
-#include <unordered_map>
+#include "../../include/altacore/simple-map.hpp"
 
 const AltaCore::AST::NodeType AltaCore::AST::FunctionCallExpression::nodeType() {
   return NodeType::FunctionCallExpression;
@@ -13,24 +13,24 @@ AltaCore::AST::FunctionCallExpression::FunctionCallExpression(std::shared_ptr<Al
   arguments(_arguments)
   {};
 
-std::tuple<size_t, std::unordered_map<size_t, size_t>, std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<AltaCore::AST::ExpressionNode>, std::shared_ptr<AltaCore::DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<AltaCore::AST::ExpressionNode>, std::shared_ptr<AltaCore::DH::ExpressionNode>>>>>> AltaCore::AST::FunctionCallExpression::findCompatibleCall(std::vector<std::tuple<std::string, std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>> arguments, std::vector<std::shared_ptr<DET::Type>> targetTypes) {
+std::tuple<size_t, ALTACORE_MAP<size_t, size_t>, std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<AltaCore::AST::ExpressionNode>, std::shared_ptr<AltaCore::DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<AltaCore::AST::ExpressionNode>, std::shared_ptr<AltaCore::DH::ExpressionNode>>>>>> AltaCore::AST::FunctionCallExpression::findCompatibleCall(std::vector<std::tuple<std::string, std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>> arguments, std::vector<std::shared_ptr<DET::Type>> targetTypes) {
   if (targetTypes.size() < 1) {
     throw std::runtime_error("Can't call an unknown expression like a function");
   }
 
   bool found = false; // whether we found the right function
   bool possible = false; // whether we found any function at all
-  std::vector<std::tuple<size_t, std::vector<size_t>, std::shared_ptr<DET::Type>, std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>>, std::unordered_map<size_t, size_t>>> compatibles;
+  std::vector<std::tuple<size_t, std::vector<size_t>, std::shared_ptr<DET::Type>, std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>>, ALTACORE_MAP<size_t, size_t>>> compatibles;
   for (size_t index = 0; index < targetTypes.size(); index++) {
     auto& targetType = targetTypes[index];
     if (!targetType->isFunction) continue;
     possible = true;
     //if (targetType->parameters.size() != arguments.size()) continue;
-    std::unordered_map<size_t, std::pair<std::string, ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>>> argumentsInOrder;
+    ALTACORE_MAP<size_t, std::pair<std::string, ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>>> argumentsInOrder;
     std::vector<size_t> compatiblities(targetType->parameters.size(), 0);
     size_t funcArgIndex = 0;
     bool ok = arguments.size() >= targetType->requiredArgumentCount();
-    std::unordered_map<size_t, size_t> argMap;
+    ALTACORE_MAP<size_t, size_t> argMap;
     for (size_t i = 0; i < arguments.size(); i++) {
       if (!ok) break;
       auto& [argName, argExpr, argDet] = arguments[i];
@@ -131,7 +131,7 @@ std::tuple<size_t, std::unordered_map<size_t, size_t>, std::vector<ALTACORE_VARI
   std::vector<size_t> mostCompatibleCompatiblities;
   std::shared_ptr<DET::Type> mostCompatibleType = nullptr;
   std::vector<ALTACORE_VARIANT<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>, std::vector<std::pair<std::shared_ptr<ExpressionNode>, std::shared_ptr<DH::ExpressionNode>>>>> mostCompatibleArguments;
-  std::unordered_map<size_t, size_t> mostCompatibleArgMap;
+  ALTACORE_MAP<size_t, size_t> mostCompatibleArgMap;
   for (auto& [index, compatabilities, type, args, argMap]: compatibles) {
     if (mostCompatibleIndex != SIZE_MAX) {
       size_t numberGreater = 0;

--- a/src/ast/super-class-fetch.cpp
+++ b/src/ast/super-class-fetch.cpp
@@ -59,7 +59,7 @@ ALTACORE_AST_DETAIL_D(SuperClassFetch) {
 
   /*
   std::vector<std::shared_ptr<DET::Type>> targetTypes;
-  std::unordered_map<size_t, size_t> indexMap;
+  ALTACORE_MAP<size_t, size_t> indexMap;
   for (size_t i = 0; i < info->superclass->constructors.size(); i++) {
     auto& constr = info->superclass->constructors[i];
     if (!scope->canSee(constr)) {

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1,9 +1,10 @@
 #include "../include/altacore/attributes.hpp"
+#include "../include/altacore/simple-map.hpp"
 
 namespace AltaCore {
   namespace Attributes {
     std::vector<Attribute> registeredGlobalAttributes;
-    std::map<std::string, std::vector<Attribute>> registeredFileAttributes;
+    ALTACORE_MAP<std::string, std::vector<Attribute>> registeredFileAttributes;
   };
 };
 

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -5,7 +5,7 @@
 namespace AltaCore {
   namespace Modules {
     Filesystem::Path standardLibraryPath;
-    std::unordered_map<std::string, std::shared_ptr<AltaCore::AST::RootNode>> importCache;
+    ALTACORE_MAP<std::string, std::shared_ptr<AltaCore::AST::RootNode>> importCache;
     std::function<std::shared_ptr<AST::RootNode>(std::string importRequest, Filesystem::Path requestingModulePath)> parseModule = [](std::string importRequest, Filesystem::Path requestingModulePath) -> std::shared_ptr<AST::RootNode> {
       auto modPath = resolve(importRequest, requestingModulePath);
       if (auto& imp = importCache[modPath.absolutify().toString()]) {

--- a/src/preprocessor.cpp
+++ b/src/preprocessor.cpp
@@ -251,7 +251,7 @@ AltaCore::Preprocessor::Expression AltaCore::Preprocessor::ExpressionParser::def
   return true;
 };
 
-AltaCore::Preprocessor::ExpressionParser::ExpressionParser(std::vector<Lexer::Token> _tokens, std::map<std::string, Expression>& _definitions):
+AltaCore::Preprocessor::ExpressionParser::ExpressionParser(std::vector<Lexer::Token> _tokens, ALTACORE_MAP<std::string, Expression>& _definitions):
   GenericParser(_tokens),
   definitions(_definitions)
   {};


### PR DESCRIPTION
Title says it all. Well, also, just FYI: all our uses of `std::map` were replaced with `std::unordered_map` (on platforms that support it), which is faster and supports the same API and, since we don't care about order, is identical to `std::map`.