### PR TITLE
Generic classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(altacore
   "${PROJECT_SOURCE_DIR}/src/ast/retrieval-node.cpp"
   "${PROJECT_SOURCE_DIR}/src/ast/super-class-fetch.cpp"
   "${PROJECT_SOURCE_DIR}/src/ast/instanceof-expression.cpp"
+  "${PROJECT_SOURCE_DIR}/src/ast/generic.cpp"
 
   # DET nodes
   "${PROJECT_SOURCE_DIR}/src/det/node.cpp"

--- a/include/altacore/ast-shared.hpp
+++ b/include/altacore/ast-shared.hpp
@@ -54,6 +54,7 @@ namespace AltaCore {
       RetrievalNode,
       SuperClassFetch,
       InstanceofExpression,
+      Generic,
     };
 
     static const char* const NodeType_names[] = {
@@ -101,6 +102,7 @@ namespace AltaCore {
       "RetrievalNode",
       "SuperClassFetch",
       "InstanceofExpression",
+      "Generic",
     };
 
     enum class OperatorType {

--- a/include/altacore/ast.hpp
+++ b/include/altacore/ast.hpp
@@ -46,5 +46,6 @@
 #include "ast/retrieval-node.hpp"
 #include "ast/super-class-fetch.hpp"
 #include "ast/instanceof-expression.hpp"
+#include "ast/generic.hpp"
 
 #endif // ALTACORE_AST_HPP

--- a/include/altacore/ast/accessor.hpp
+++ b/include/altacore/ast/accessor.hpp
@@ -4,6 +4,7 @@
 #include "retrieval-node.hpp"
 #include "../det/scope-item.hpp"
 #include "../det/function.hpp"
+#include "type.hpp"
 
 namespace AltaCore {
   namespace AST {
@@ -12,6 +13,7 @@ namespace AltaCore {
         virtual const NodeType nodeType();
 
         std::shared_ptr<AST::ExpressionNode> target = nullptr;
+        std::vector<std::shared_ptr<Type>> genericArguments;
 
         Accessor(std::shared_ptr<AST::ExpressionNode> target, std::string query);
 

--- a/include/altacore/ast/class-definition-node.hpp
+++ b/include/altacore/ast/class-definition-node.hpp
@@ -12,7 +12,7 @@
 
 namespace AltaCore {
   namespace AST {
-    class ClassDefinitionNode: public StatementNode {
+    class ClassDefinitionNode: public StatementNode, public std::enable_shared_from_this<ClassDefinitionNode> {
       public:
         virtual const NodeType nodeType();
 
@@ -26,6 +26,8 @@ namespace AltaCore {
 
         ALTACORE_AST_DETAIL(ClassDefinitionNode);
         ALTACORE_AST_VALIDATE;
+
+        std::shared_ptr<DET::Class> instantiateGeneric(std::shared_ptr<DH::ClassDefinitionNode> info, std::vector<std::shared_ptr<DET::Type>> genericArguments);
     };
   };
 };

--- a/include/altacore/ast/class-definition-node.hpp
+++ b/include/altacore/ast/class-definition-node.hpp
@@ -8,6 +8,7 @@
 #include "retrieval-node.hpp"
 #include <vector>
 #include <string>
+#include "generic.hpp"
 
 namespace AltaCore {
   namespace AST {
@@ -16,6 +17,7 @@ namespace AltaCore {
         virtual const NodeType nodeType();
 
         std::vector<std::string> modifiers;
+        std::vector<std::shared_ptr<Generic>> generics;
         std::string name;
         std::vector<std::shared_ptr<ClassStatementNode>> statements;
         std::vector<std::shared_ptr<RetrievalNode>> parents;

--- a/include/altacore/ast/fetch.hpp
+++ b/include/altacore/ast/fetch.hpp
@@ -4,12 +4,16 @@
 #include "retrieval-node.hpp"
 #include "../det/scope-item.hpp"
 #include "../det/type.hpp"
+#include "type.hpp"
 
 namespace AltaCore {
   namespace AST {
+    class Accessor; // forward declaration
     class Fetch: public RetrievalNode {
       public:
         virtual const NodeType nodeType();
+
+        std::vector<std::shared_ptr<Type>> genericArguments;
 
         Fetch(std::string query);
 

--- a/include/altacore/ast/generic.hpp
+++ b/include/altacore/ast/generic.hpp
@@ -15,6 +15,8 @@ namespace AltaCore {
         Generic(std::string _name):
           name(_name)
           {};
+
+        ALTACORE_AST_DETAIL(Generic);
     };
   };
 };

--- a/include/altacore/ast/generic.hpp
+++ b/include/altacore/ast/generic.hpp
@@ -1,0 +1,22 @@
+#ifndef ALTACORE_AST_GENERIC_HPP
+#define ALTACORE_AST_GENERIC_HPP
+
+#include "node.hpp"
+#include <string>
+
+namespace AltaCore {
+  namespace AST {
+    class Generic: public Node {
+      public:
+        virtual const NodeType nodeType();
+
+        std::string name;
+
+        Generic(std::string _name):
+          name(_name)
+          {};
+    };
+  };
+};
+
+#endif /* ALTACORE_AST_GENERIC_HPP */

--- a/include/altacore/det/class.hpp
+++ b/include/altacore/det/class.hpp
@@ -33,6 +33,7 @@ namespace AltaCore {
         std::vector<std::shared_ptr<Variable>> itemsToCopy;
 
         std::vector<std::shared_ptr<Type>> hoistedFunctionalTypes;
+        std::vector<std::shared_ptr<Type>> genericArguments;
 
         std::weak_ptr<AST::ClassDefinitionNode> ast;
         std::weak_ptr<DetailHandles::ClassDefinitionNode> info;

--- a/include/altacore/det/class.hpp
+++ b/include/altacore/det/class.hpp
@@ -6,8 +6,14 @@
 #include <string>
 
 namespace AltaCore {
+  namespace AST {
+    class ClassDefinitionNode;
+  };
+  namespace DetailHandles {
+    class ClassDefinitionNode;
+  };
   namespace DET {
-    class Variable; // forward declaration
+    class Variable;
 
     class Class: public ScopeItem {
       public:
@@ -28,9 +34,13 @@ namespace AltaCore {
 
         std::vector<std::shared_ptr<Type>> hoistedFunctionalTypes;
 
+        std::weak_ptr<AST::ClassDefinitionNode> ast;
+        std::weak_ptr<DetailHandles::ClassDefinitionNode> info;
+
         Class(std::string name, std::shared_ptr<Scope> parentScope, std::vector<std::shared_ptr<Class>> parents = {});
 
         bool hasParent(std::shared_ptr<Class> parent) const;
+        std::shared_ptr<Class> instantiateGeneric(std::vector<std::shared_ptr<Type>> genericArguments);
     };
   };
 };

--- a/include/altacore/det/module.hpp
+++ b/include/altacore/det/module.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include "../fs.hpp"
 #include "../modules.hpp"
+#include "../simple-map.hpp"
 
 namespace AltaCore {
   namespace AST {
@@ -29,10 +30,14 @@ namespace AltaCore {
         std::shared_ptr<Module> parent = nullptr;
         std::vector<std::shared_ptr<Module>> dependencies;
         std::vector<std::shared_ptr<Module>> dependents;
+        ALTACORE_MAP<std::string, std::vector<std::shared_ptr<Module>>> genericDependencies;
+        std::vector<std::shared_ptr<ScopeItem>> genericsUsed;
         std::weak_ptr<AST::RootNode> ast;
         Modules::PackageInfo packageInfo;
 
         std::vector<std::shared_ptr<Type>> hoistedFunctionalTypes;
+
+        std::vector<std::shared_ptr<ScopeItem>> hoistedGenerics;
 
         Module();
     };

--- a/include/altacore/det/scope-item.hpp
+++ b/include/altacore/det/scope-item.hpp
@@ -20,6 +20,7 @@ namespace AltaCore {
         Visibility visibility = Visibility::Public;
         std::weak_ptr<Scope> parentScope;
         std::string name;
+        size_t genericParameterCount = 0;
 
         ScopeItem(std::string name, std::shared_ptr<Scope> parentScope = nullptr);
 

--- a/include/altacore/det/scope-item.hpp
+++ b/include/altacore/det/scope-item.hpp
@@ -22,6 +22,11 @@ namespace AltaCore {
         std::string name;
         size_t genericParameterCount = 0;
 
+        std::vector<std::shared_ptr<ScopeItem>> privateHoistedGenerics;
+        std::vector<std::shared_ptr<ScopeItem>> publicHoistedGenerics;
+
+        bool instantiatedFromSamePackage = false;
+
         ScopeItem(std::string name, std::shared_ptr<Scope> parentScope = nullptr);
 
         static std::vector<std::shared_ptr<ScopeItem>> getUnderlyingItems(std::shared_ptr<DH::Node> node);

--- a/include/altacore/det/scope.hpp
+++ b/include/altacore/det/scope.hpp
@@ -37,6 +37,7 @@ namespace AltaCore {
 
         std::vector<std::shared_ptr<ScopeItem>> findAll(std::string name, std::vector<std::shared_ptr<Type>> excludeTypes = {}, bool searchParents = true, std::shared_ptr<Scope> originScope = nullptr);
         void hoist(std::shared_ptr<Type> whatToHoist);
+        void hoist(std::shared_ptr<ScopeItem> generic);
 
         bool hasParent(std::shared_ptr<Scope> parent) const;
 

--- a/include/altacore/detail-handles.hpp
+++ b/include/altacore/detail-handles.hpp
@@ -95,6 +95,8 @@ namespace AltaCore {
       size_t narrowedToIndex = 0;
       std::shared_ptr<DET::Type> targetType = nullptr;
       bool getsVariableLength = false;
+      std::vector<std::shared_ptr<Type>> genericArgumentDetails;
+      std::vector<std::shared_ptr<DET::Type>> genericArguments;
     };
 
     class AssignmentExpression: public ExpressionNode {
@@ -231,6 +233,8 @@ namespace AltaCore {
       ALTACORE_DH_CTOR(Fetch, RetrievalNode);
 
       std::shared_ptr<DET::ScopeItem> narrowedTo;
+      std::vector<std::shared_ptr<Type>> genericArgumentDetails;
+      std::vector<std::shared_ptr<DET::Type>> genericArguments;
     };
     class FunctionCallExpression: public ExpressionNode {
       ALTACORE_DH_CTOR(FunctionCallExpression, ExpressionNode);

--- a/include/altacore/detail-handles.hpp
+++ b/include/altacore/detail-handles.hpp
@@ -73,6 +73,8 @@ namespace AltaCore {
     class WhileLoopStatement;
     class RetrievalNode;
     class SuperClassFetch;
+    class GenericClassInstantiationDefinitionNode;
+    class Generic;
 
     class RetrievalNode: public ExpressionNode {
       ALTACORE_DH_CTOR(RetrievalNode, ExpressionNode);
@@ -143,6 +145,7 @@ namespace AltaCore {
 
       std::vector<std::shared_ptr<ClassStatementNode>> statements;
       std::vector<std::shared_ptr<RetrievalNode>> parents;
+      std::vector<std::shared_ptr<GenericClassInstantiationDefinitionNode>> genericInstantiations;
 
       bool isExport = false;
       bool isLiteral = false;
@@ -156,6 +159,12 @@ namespace AltaCore {
       std::shared_ptr<ClassSpecialMethodDefinitionStatement> defaultDestructorDetail = nullptr;
       std::shared_ptr<AST::ClassSpecialMethodDefinitionStatement> defaultCopyConstructor = nullptr;
       std::shared_ptr<ClassSpecialMethodDefinitionStatement> defaultCopyConstructorDetail = nullptr;
+      std::vector<std::shared_ptr<Generic>> genericDetails;
+    };
+    class GenericClassInstantiationDefinitionNode: public ClassDefinitionNode {
+      ALTACORE_DH_CTOR(GenericClassInstantiationDefinitionNode, ClassDefinitionNode);
+
+      std::weak_ptr<ClassDefinitionNode> generic;
     };
     class ClassInstantiationExpression: public ExpressionNode {
       ALTACORE_DH_CTOR(ClassInstantiationExpression, ExpressionNode);
@@ -363,6 +372,11 @@ namespace AltaCore {
 
       std::shared_ptr<ExpressionNode> target = nullptr;
       std::shared_ptr<Type> type = nullptr;
+    };
+    class Generic: public Node {
+      ALTACORE_DH_CTOR(Generic, Node);
+
+      std::shared_ptr<DET::Alias> alias = nullptr;
     };
 
     #undef ALTACORE_DH_CTOR

--- a/include/altacore/parser.hpp
+++ b/include/altacore/parser.hpp
@@ -162,6 +162,7 @@ namespace AltaCore {
       SuperClassFetch,
       Instanceof,
       Generic,
+      NullRule,
     };
 
     enum class PrepoRuleType {

--- a/include/altacore/parser.hpp
+++ b/include/altacore/parser.hpp
@@ -108,6 +108,7 @@ namespace AltaCore {
       {
         "literal",
         "export",
+        "generic",
       },
       {
         "export",
@@ -160,6 +161,7 @@ namespace AltaCore {
       TypeAlias,
       SuperClassFetch,
       Instanceof,
+      Generic,
     };
 
     enum class PrepoRuleType {

--- a/src/ast/accessor.cpp
+++ b/src/ast/accessor.cpp
@@ -1,6 +1,7 @@
 #include "../../include/altacore/ast/accessor.hpp"
 #include "../../include/altacore/ast/fetch.hpp"
 #include "../../include/altacore/det.hpp"
+#include "../../include/altacore/util.hpp"
 
 const AltaCore::AST::NodeType AltaCore::AST::Accessor::nodeType() {
   return NodeType::Accessor;
@@ -198,7 +199,15 @@ ALTACORE_AST_DETAIL_D(Accessor) {
       }
 
       if (auto klass = std::dynamic_pointer_cast<DET::Class>(item)) {
-        info->items[i] = klass->instantiateGeneric(info->genericArguments);
+        auto newKlass = klass->instantiateGeneric(info->genericArguments);
+        info->items[i] = newKlass;
+        auto thisMod = Util::getModule(info->inputScope.get()).lock();
+        thisMod->genericsUsed.push_back(newKlass);
+        auto thatMod = Util::getModule(newKlass->parentScope.lock().get()).lock();
+        if (thisMod->packageInfo.name == thatMod->packageInfo.name) {
+          newKlass->instantiatedFromSamePackage = true;
+        }
+        info->inputScope->hoist(info->items[i]);
         if (isNarrowedTo) {
           info->narrowedTo = info->items[i];
         }

--- a/src/ast/class-definition-node.cpp
+++ b/src/ast/class-definition-node.cpp
@@ -211,6 +211,9 @@ std::shared_ptr<AltaCore::DET::Class> AltaCore::AST::ClassDefinitionNode::instan
 
   inst->klass->genericArguments = genericArguments;
 
+  auto thisMod = Util::getModule(info->inputScope.get()).lock();
+  auto& gDepEntry = thisMod->genericDependencies[inst->klass->id];
+
   for (size_t i = 0; i < generics.size(); i++) {
     auto& generic = generics[i];
     auto& genericArg = genericArguments[i];
@@ -218,6 +221,11 @@ std::shared_ptr<AltaCore::DET::Class> AltaCore::AST::ClassDefinitionNode::instan
     auto det = generic->fullDetail(inst->klass->scope);
     det->alias->target = genericArg;
     inst->genericDetails.push_back(det);
+
+    if (genericArg->klass) {
+      auto thatMod = Util::getModule(genericArg->klass->parentScope.lock().get()).lock();
+      gDepEntry.push_back(thatMod);
+    }
   }
 
   AltaCoreClassHelpers::detailClass(inst, this);

--- a/src/ast/class-definition-node.cpp
+++ b/src/ast/class-definition-node.cpp
@@ -2,6 +2,116 @@
 #include "../../include/altacore/ast/class-special-method-definition-statement.hpp"
 #include "../../include/altacore/util.hpp"
 
+namespace AltaCoreClassHelpers {
+  template<class T> void detailClass(std::shared_ptr<T> info, AltaCore::AST::ClassDefinitionNode* self) {
+    using namespace AltaCore::AST;
+    namespace DH = AltaCore::DetailHandles;
+    namespace DET = AltaCore::DET;
+
+    for (auto& parent: self->parents) {
+      auto det = parent->fullDetail(info->klass->scope);
+      info->parents.push_back(det);
+      if (det->items.size() != 1 || det->items.back()->nodeType() != DET::NodeType::Class) {
+        throw AltaCore::Errors::ValidationError("no class found for the given parent expression", self->position);
+      }
+      info->klass->parents.push_back(std::dynamic_pointer_cast<DET::Class>(det->items.back()));
+    }
+
+    auto loop = [&](std::vector<std::shared_ptr<ClassStatementNode>>& tgt, bool noBodies = false) -> void {
+      if (noBodies) {
+        for (auto stmt: tgt) {
+          auto det = stmt->fullDetail(info->klass->scope, true);
+          info->statements.push_back(det);
+          if (stmt->nodeType() == NodeType::ClassSpecialMethodDefinitionStatement) {
+            auto special = std::dynamic_pointer_cast<ClassSpecialMethodDefinitionStatement>(stmt);
+            auto specialDet = std::dynamic_pointer_cast<DH::ClassSpecialMethodDefinitionStatement>(det);
+            if (special->type == SpecialClassMethod::Constructor) {
+              info->klass->constructors.push_back(specialDet->method);
+              if (specialDet->method->parameters.size() == 0 || (specialDet->method->parameters.size() == 1 && std::get<2>(specialDet->method->parameters.front()))) {
+                info->klass->defaultConstructor = specialDet->method;
+              }
+              if (specialDet->isCopyConstructor) {
+                info->klass->copyConstructor = specialDet->method;
+              }
+            } else {
+              if (info->klass->destructor) {
+                throw AltaCore::Errors::ValidationError("can't have more than one destructor for a class", self->position);
+              }
+              info->klass->destructor = specialDet->method;
+            }
+          }
+        }
+      } else {
+        for (size_t i = 0; i < tgt.size(); i++) {
+          auto& stmt = tgt[i];
+          auto& det = info->statements[i];
+          stmt->detail(det, false);
+        }
+      }
+    };
+
+    loop(self->statements, true);
+    loop(self->statements);
+
+    if (info->klass->constructors.size() == 0) {
+      info->createDefaultConstructor = true;
+      info->defaultConstructor = std::make_shared<ClassSpecialMethodDefinitionStatement>(Visibility::Public, SpecialClassMethod::Constructor);
+      info->defaultConstructor->body = std::make_shared<BlockNode>();
+      info->defaultConstructorDetail = info->defaultConstructor->fullDetail(info->klass->scope);
+      info->klass->constructors.push_back(info->defaultConstructorDetail->method);
+    }
+
+    bool requiresDtor = false;
+    bool requiresCopyCtor = false;
+    for (auto& item: info->klass->scope->items) {
+      if (item->nodeType() != DET::NodeType::Variable) continue;
+      if (item->name == "this") continue;
+
+      auto var = std::dynamic_pointer_cast<DET::Variable>(item);
+
+      if (var->type->isNative) continue;
+      if (var->type->indirectionLevel() > 0) continue;
+
+      if (var->type->klass->destructor) {
+        requiresDtor = true;
+        info->klass->itemsToDestroy.push_back(var);
+      }
+
+      if (var->type->klass->copyConstructor) {
+        requiresCopyCtor = true;
+        info->klass->itemsToCopy.push_back(var);
+      }
+    }
+
+    if (!info->klass->destructor && requiresDtor) {
+      info->createDefaultDestructor = true;
+      info->defaultDestructor = std::make_shared<ClassSpecialMethodDefinitionStatement>(Visibility::Public, SpecialClassMethod::Destructor);
+      info->defaultDestructor->body = std::make_shared<BlockNode>();
+      info->defaultDestructorDetail = info->defaultDestructor->fullDetail(info->klass->scope);
+      info->klass->destructor = info->defaultDestructorDetail->method;
+    }
+
+    if (!info->klass->copyConstructor && requiresCopyCtor) {
+      info->createDefaultCopyConstructor = true;
+      info->defaultCopyConstructor = std::make_shared<ClassSpecialMethodDefinitionStatement>(Visibility::Public, SpecialClassMethod::Constructor);
+      info->defaultCopyConstructor->body = std::make_shared<BlockNode>();
+
+      // this is very hacky and i don't like it
+      //
+      // looks like my own API design came and bit
+      // me in the butt
+      auto selfType = std::make_shared<Type>();
+      selfType->_injected_type = std::make_shared<DET::Type>(info->klass, std::vector<uint8_t> { (uint8_t)TypeModifierFlag::Reference });
+
+      info->defaultCopyConstructor->parameters.push_back(std::make_shared<Parameter>("other", selfType));
+      info->defaultCopyConstructorDetail = info->defaultCopyConstructor->fullDetail(info->klass->scope);
+      info->defaultCopyConstructorDetail->isCopyConstructor = true;
+      info->defaultCopyConstructorDetail->isDefaultCopyConstructor = true;
+      info->klass->copyConstructor = info->defaultCopyConstructorDetail->method;
+    }
+  };
+};
+
 const AltaCore::AST::NodeType AltaCore::AST::ClassDefinitionNode::nodeType() {
   return NodeType::ClassDefinitionNode;
 };
@@ -13,21 +123,19 @@ AltaCore::AST::ClassDefinitionNode::ClassDefinitionNode(std::string _name):
 ALTACORE_AST_DETAIL_D(ClassDefinitionNode) {
   ALTACORE_MAKE_DH(ClassDefinitionNode);
 
-  std::vector<std::shared_ptr<DET::Class>> parentClasses;
-  for (auto& parent: parents) {
-    auto det = parent->fullDetail(scope);
-    info->parents.push_back(det);
-    if (det->items.size() != 1 || det->items.back()->nodeType() != DET::NodeType::Class) {
-      ALTACORE_DETAILING_ERROR("no class found for the given parent expression");
-    }
-    parentClasses.push_back(std::dynamic_pointer_cast<DET::Class>(det->items.back()));
-  }
+  info->klass = DET::Class::create(name, scope, {});
+  info->klass->genericParameterCount = generics.size();
+  info->klass->ast = shared_from_this();
+  info->klass->info = info;
 
-  info->klass = DET::Class::create(name, scope, parentClasses);
-  scope->items.push_back(info->klass);
+  for (auto generic: generics) {
+    info->genericDetails.push_back(generic->fullDetail(info->klass->scope));
+  }
 
   info->isLiteral = std::find(modifiers.begin(), modifiers.end(), "literal") != modifiers.end();
   info->isExport = std::find(modifiers.begin(), modifiers.end(), "export") != modifiers.end();
+
+  scope->items.push_back(info->klass);
 
   if (info->isExport) {
     if (auto mod = Util::getModule(scope.get()).lock()) {
@@ -35,98 +143,11 @@ ALTACORE_AST_DETAIL_D(ClassDefinitionNode) {
     }
   }
 
-  auto loop = [&](std::vector<std::shared_ptr<ClassStatementNode>>& tgt, bool noBodies = false) -> void {
-    if (noBodies) {
-      for (auto stmt: tgt) {
-        auto det = stmt->fullDetail(info->klass->scope, true);
-        info->statements.push_back(det);
-        if (stmt->nodeType() == NodeType::ClassSpecialMethodDefinitionStatement) {
-          auto special = std::dynamic_pointer_cast<ClassSpecialMethodDefinitionStatement>(stmt);
-          auto specialDet = std::dynamic_pointer_cast<DH::ClassSpecialMethodDefinitionStatement>(det);
-          if (special->type == SpecialClassMethod::Constructor) {
-            info->klass->constructors.push_back(specialDet->method);
-            if (specialDet->method->parameters.size() == 0 || (specialDet->method->parameters.size() == 1 && std::get<2>(specialDet->method->parameters.front()))) {
-              info->klass->defaultConstructor = specialDet->method;
-            }
-            if (specialDet->isCopyConstructor) {
-              info->klass->copyConstructor = specialDet->method;
-            }
-          } else {
-            if (info->klass->destructor) {
-              ALTACORE_VALIDATION_ERROR("can't have more than one destructor for a class");
-            }
-            info->klass->destructor = specialDet->method;
-          }
-        }
-      }
-    } else {
-      for (size_t i = 0; i < tgt.size(); i++) {
-        auto& stmt = tgt[i];
-        auto& det = info->statements[i];
-        stmt->detail(det, false);
-      }
-    }
-  };
-
-  loop(statements, true);
-  loop(statements);
-
-  if (info->klass->constructors.size() == 0) {
-    info->createDefaultConstructor = true;
-    info->defaultConstructor = std::make_shared<ClassSpecialMethodDefinitionStatement>(Visibility::Public, SpecialClassMethod::Constructor);
-    info->defaultConstructor->body = std::make_shared<BlockNode>();
-    info->defaultConstructorDetail = info->defaultConstructor->fullDetail(info->klass->scope);
-    info->klass->constructors.push_back(info->defaultConstructorDetail->method);
+  if (generics.size() > 0) {
+    return info;
   }
 
-  bool requiresDtor = false;
-  bool requiresCopyCtor = false;
-  for (auto& item: info->klass->scope->items) {
-    if (item->nodeType() != DET::NodeType::Variable) continue;
-    if (item->name == "this") continue;
-
-    auto var = std::dynamic_pointer_cast<DET::Variable>(item);
-
-    if (var->type->isNative) continue;
-    if (var->type->indirectionLevel() > 0) continue;
-
-    if (var->type->klass->destructor) {
-      requiresDtor = true;
-      info->klass->itemsToDestroy.push_back(var);
-    }
-
-    if (var->type->klass->copyConstructor) {
-      requiresCopyCtor = true;
-      info->klass->itemsToCopy.push_back(var);
-    }
-  }
-
-  if (!info->klass->destructor && requiresDtor) {
-    info->createDefaultDestructor = true;
-    info->defaultDestructor = std::make_shared<ClassSpecialMethodDefinitionStatement>(Visibility::Public, SpecialClassMethod::Destructor);
-    info->defaultDestructor->body = std::make_shared<BlockNode>();
-    info->defaultDestructorDetail = info->defaultDestructor->fullDetail(info->klass->scope);
-    info->klass->destructor = info->defaultDestructorDetail->method;
-  }
-
-  if (!info->klass->copyConstructor && requiresCopyCtor) {
-    info->createDefaultCopyConstructor = true;
-    info->defaultCopyConstructor = std::make_shared<ClassSpecialMethodDefinitionStatement>(Visibility::Public, SpecialClassMethod::Constructor);
-    info->defaultCopyConstructor->body = std::make_shared<BlockNode>();
-
-    // this is very hacky and i don't like it
-    //
-    // looks like my own API design came and bit
-    // me in the butt
-    auto selfType = std::make_shared<Type>();
-    selfType->_injected_type = std::make_shared<DET::Type>(info->klass, std::vector<uint8_t> { (uint8_t)TypeModifierFlag::Reference });
-
-    info->defaultCopyConstructor->parameters.push_back(std::make_shared<Parameter>("other", selfType));
-    info->defaultCopyConstructorDetail = info->defaultCopyConstructor->fullDetail(info->klass->scope);
-    info->defaultCopyConstructorDetail->isCopyConstructor = true;
-    info->defaultCopyConstructorDetail->isDefaultCopyConstructor = true;
-    info->klass->copyConstructor = info->defaultCopyConstructorDetail->method;
-  }
+  AltaCoreClassHelpers::detailClass(info, this);
 
   return info;
 };
@@ -139,10 +160,66 @@ ALTACORE_AST_VALIDATE_D(ClassDefinitionNode) {
   if (name.empty()) ALTACORE_VALIDATION_ERROR("empty name for class definition");
   for (size_t i = 0; i < statements.size(); i++) {
     auto& stmt = statements[i];
-    auto& stmtDet = info->statements[i];
     if (!stmt) ALTACORE_VALIDATION_ERROR("empty class statement in class definition");
-    stmt->validate(stack, stmtDet);
+    if (generics.size() > 0) {
+      for (auto inst: info->genericInstantiations) {
+        auto& stmtDet = inst->statements[i];
+        stmt->validate(stack, stmtDet);
+      }
+    } else {
+      auto& stmtDet = info->statements[i];
+      stmt->validate(stack, stmtDet);
+    }
   }
   if (!info->klass) ALTACORE_VALIDATION_ERROR("class defintion not detailed properly, no DET class attached");
   ALTACORE_VS_E;
+};
+
+std::shared_ptr<AltaCore::DET::Class> AltaCore::AST::ClassDefinitionNode::instantiateGeneric(std::shared_ptr<DH::ClassDefinitionNode> info, std::vector<std::shared_ptr<DET::Type>> genericArguments) {
+  if (genericArguments.size() != generics.size()) {
+    return nullptr;
+  }
+
+  for (auto genericInst: info->genericInstantiations) {
+    bool ok = true;
+    for (size_t i = 0; i < genericInst->genericDetails.size(); i++) {
+      if (auto target = std::dynamic_pointer_cast<DET::Type>(genericInst->genericDetails[i]->alias->target)) {
+        if (!target->isExactlyCompatibleWith(*genericArguments[i])) {
+          ok = false;
+          break;
+        }
+      } else {
+        ok = false;
+        break;
+      }
+    }
+
+    if (!ok) {
+      continue;
+    }
+
+    return genericInst->klass;
+  }
+
+  auto inst = std::make_shared<DH::GenericClassInstantiationDefinitionNode>(info->inputScope);
+  info->genericInstantiations.push_back(inst);
+
+  inst->klass = DET::Class::create(name, info->inputScope, {});
+  inst->klass->ast = shared_from_this();
+  inst->klass->info = info;
+
+  inst->klass->genericArguments = genericArguments;
+
+  for (size_t i = 0; i < generics.size(); i++) {
+    auto& generic = generics[i];
+    auto& genericArg = genericArguments[i];
+
+    auto det = generic->fullDetail(info->klass->scope);
+    det->alias->target = genericArg;
+    inst->genericDetails.push_back(det);
+  }
+
+  AltaCoreClassHelpers::detailClass(inst, this);
+
+  return inst->klass;
 };

--- a/src/ast/class-definition-node.cpp
+++ b/src/ast/class-definition-node.cpp
@@ -207,6 +207,7 @@ std::shared_ptr<AltaCore::DET::Class> AltaCore::AST::ClassDefinitionNode::instan
   inst->klass = DET::Class::create(name, info->inputScope, {});
   inst->klass->ast = shared_from_this();
   inst->klass->info = info;
+  inst->klass->genericParameterCount = info->klass->genericParameterCount;
 
   inst->klass->genericArguments = genericArguments;
 
@@ -214,7 +215,7 @@ std::shared_ptr<AltaCore::DET::Class> AltaCore::AST::ClassDefinitionNode::instan
     auto& generic = generics[i];
     auto& genericArg = genericArguments[i];
 
-    auto det = generic->fullDetail(info->klass->scope);
+    auto det = generic->fullDetail(inst->klass->scope);
     det->alias->target = genericArg;
     inst->genericDetails.push_back(det);
   }

--- a/src/ast/fetch.cpp
+++ b/src/ast/fetch.cpp
@@ -56,6 +56,12 @@ ALTACORE_AST_DETAIL_D(Fetch) {
     for (size_t i = 0; i < info->items.size(); i++) {
       auto& item = info->items[i];
       auto type = item->nodeType();
+      bool isNarrowedTo = false;
+
+      if (info->narrowedTo == info->items[i]) {
+        isNarrowedTo = true;
+      }
+
       if (type != DET::NodeType::Function && type != DET::NodeType::Class) {
         ALTACORE_DETAILING_ERROR(
           std::string("only functions and classes can be generic") +
@@ -66,8 +72,20 @@ ALTACORE_AST_DETAIL_D(Fetch) {
       // unequal number of generics = incompatible item; remove it
       if (item->genericParameterCount < genericArguments.size()) {
         info->items.erase(info->items.begin() + i);
+        if (isNarrowedTo) {
+          info->narrowedTo = nullptr;
+        }
         i--; // recheck this index since we shrunk the vector
         continue;
+      }
+
+      if (auto klass = std::dynamic_pointer_cast<DET::Class>(item)) {
+        info->items[i] = klass->instantiateGeneric(info->genericArguments);
+        if (isNarrowedTo) {
+          info->narrowedTo = info->items[i];
+        }
+      } else {
+        ALTACORE_DETAILING_ERROR("generic type wasn't a class or function (btw, this is impossible)");
       }
     }
   }

--- a/src/ast/fetch.cpp
+++ b/src/ast/fetch.cpp
@@ -1,4 +1,5 @@
 #include "../../include/altacore/ast/fetch.hpp"
+#include "../../include/altacore/ast/accessor.hpp"
 
 const AltaCore::AST::NodeType AltaCore::AST::Fetch::nodeType() {
   return NodeType::Fetch;
@@ -40,6 +41,36 @@ ALTACORE_AST_DETAIL_D(Fetch) {
   }
 
   info->items = items;
+
+  for (size_t i = 0; i < genericArguments.size(); i++) {
+    auto& arg = genericArguments[i];
+    auto det = arg->fullDetail(scope);
+    info->genericArgumentDetails.push_back(det);
+    if (!det->type) {
+      ALTACORE_DETAILING_ERROR("failed to detail generic argument as a type");
+    }
+    info->genericArguments.push_back(det->type);
+  }
+
+  if (genericArguments.size() > 0) {
+    for (size_t i = 0; i < info->items.size(); i++) {
+      auto& item = info->items[i];
+      auto type = item->nodeType();
+      if (type != DET::NodeType::Function && type != DET::NodeType::Class) {
+        ALTACORE_DETAILING_ERROR(
+          std::string("only functions and classes can be generic") +
+          ((info->items.size() > 1) ? "(try narrowing the retrieval)" : "")
+        );
+      }
+
+      // unequal number of generics = incompatible item; remove it
+      if (item->genericParameterCount < genericArguments.size()) {
+        info->items.erase(info->items.begin() + i);
+        i--; // recheck this index since we shrunk the vector
+        continue;
+      }
+    }
+  }
 
   return info;
 };

--- a/src/ast/generic.cpp
+++ b/src/ast/generic.cpp
@@ -1,5 +1,23 @@
 #include "../../include/altacore/ast/generic.hpp"
+#include "../../include/altacore/det/alias.hpp"
+#include "../../include/altacore/det/type.hpp"
 
 const AltaCore::AST::NodeType AltaCore::AST::Generic::nodeType() {
   return NodeType::Generic;
+};
+
+ALTACORE_AST_DETAIL_D(Generic) {
+  ALTACORE_MAKE_DH(Generic);
+
+  // TL;DR: we use void to make possible errors easier to detect
+  //
+  // void type as default is as close to null as we can get
+  //
+  // it is unacceptable for most operations, thus leading to runtime
+  // errors and making it easier to detect accidental leakage of default
+  // generic type alias values
+  info->alias = std::make_shared<DET::Alias>(name, std::make_shared<DET::Type>(DET::NativeType::Void), info->inputScope);
+  info->inputScope->items.push_back(info->alias);
+
+  return info;
 };

--- a/src/ast/generic.cpp
+++ b/src/ast/generic.cpp
@@ -1,0 +1,5 @@
+#include "../../include/altacore/ast/generic.hpp"
+
+const AltaCore::AST::NodeType AltaCore::AST::Generic::nodeType() {
+  return NodeType::Generic;
+};

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -58,7 +58,8 @@ std::shared_ptr<AltaCore::DH::Node> AltaCore::AST::Type::detail(std::shared_ptr<
     }
 
     if (item && item->nodeType() == DET::NodeType::Type) {
-      info->type = std::dynamic_pointer_cast<DET::Type>(item);
+      info->type = std::dynamic_pointer_cast<DET::Type>(item)->copy();
+      info->type->modifiers.insert(info->type->modifiers.begin(), modifiers.begin(), modifiers.end());
     } else if (isAny) {
       info->type = std::make_shared<DET::Type>();
     } else if (isNative) {

--- a/src/det/class.cpp
+++ b/src/det/class.cpp
@@ -1,5 +1,6 @@
 #include "../../include/altacore/det/class.hpp"
 #include "../../include/altacore/det/variable.hpp"
+#include "../../include/altacore/ast/class-definition-node.hpp"
 
 const AltaCore::DET::NodeType AltaCore::DET::Class::nodeType() {
   return NodeType::Class;
@@ -37,4 +38,16 @@ bool AltaCore::DET::Class::hasParent(std::shared_ptr<Class> parent) const {
     if (myParent->hasParent(parent)) return true;
   }
   return false;
+};
+
+std::shared_ptr<AltaCore::DET::Class> AltaCore::DET::Class::instantiateGeneric(std::vector<std::shared_ptr<Type>> genericArguments) {
+  if (auto klass = ast.lock()) {
+    auto inf = info.lock();
+    if (!inf) {
+      return nullptr;
+    }
+    return klass->instantiateGeneric(inf, genericArguments);
+  } else {
+    return nullptr;
+  }
 };

--- a/src/det/function.cpp
+++ b/src/det/function.cpp
@@ -1,4 +1,5 @@
 #include "../../include/altacore/det/function.hpp"
+#include "../../include/altacore/det/class.hpp"
 
 const AltaCore::DET::NodeType AltaCore::DET::Function::nodeType() {
   return NodeType::Function;
@@ -40,10 +41,16 @@ std::shared_ptr<AltaCore::DET::Function> AltaCore::DET::Function::create(std::sh
     if (type->isFunction) {
       func->publicHoistedFunctionalTypes.push_back(type);
     }
+    if (type->klass && type->klass->genericParameterCount > 0) {
+      func->publicHoistedGenerics.push_back(type->klass);
+    }
   }
 
   if (returnType->isFunction) {
     func->publicHoistedFunctionalTypes.push_back(returnType);
+  }
+  if (returnType->klass && returnType->klass->genericParameterCount > 0) {
+    func->publicHoistedGenerics.push_back(returnType->klass);
   }
 
   return func;


### PR DESCRIPTION
Implements what that title says, but also has a few other minor features/bug fixes:
  * Prepend type modifiers to resolved types (e.g. `ptr Size` actually produces `ptr unsigned long long int`, not `unsigned long long int`)
  * Allow functions calls to be used as accessor targets (e.g. `foo().bar` now works)