### PR TITLE
Operators overloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(altacore
   "${PROJECT_SOURCE_DIR}/src/ast/bitfield-definition-node.cpp"
   "${PROJECT_SOURCE_DIR}/src/ast/lambda-expression.cpp"
   "${PROJECT_SOURCE_DIR}/src/ast/special-fetch-expression.cpp"
+  "${PROJECT_SOURCE_DIR}/src/ast/class-operator-definition-statement.cpp"
 
   # DET nodes
   "${PROJECT_SOURCE_DIR}/src/det/node.cpp"

--- a/include/altacore/ast-shared.hpp
+++ b/include/altacore/ast-shared.hpp
@@ -75,6 +75,7 @@ namespace AltaCore {
       BitfieldDefinitionNode,
       LambdaExpression,
       SpecialFetchExpression,
+      ClassOperatorDefinitionStatement,
     };
 
     static const char* const NodeType_names[] = {
@@ -141,6 +142,7 @@ namespace AltaCore {
       "BitfieldDefinitionNode",
       "LambdaExpression",
       "SpecialFetchExpression",
+      "ClassOperatorDefinitionStatement",
     };
   };
 };

--- a/include/altacore/ast.hpp
+++ b/include/altacore/ast.hpp
@@ -65,5 +65,6 @@
 #include "ast/bitfield-definition-node.hpp"
 #include "ast/lambda-expression.hpp"
 #include "ast/special-fetch-expression.hpp"
+#include "ast/class-operator-definition-statement.hpp"
 
 #endif // ALTACORE_AST_HPP

--- a/include/altacore/ast/class-operator-definition-statement.hpp
+++ b/include/altacore/ast/class-operator-definition-statement.hpp
@@ -1,0 +1,65 @@
+#ifndef ALTACORE_AST_CLASS_OPERATOR_DEFNITION_STATEMENT_HPP
+#define ALTACORE_AST_CLASS_OPERATOR_DEFNITION_STATEMENT_HPP
+
+#include "class-statement-node.hpp"
+#include "block-node.hpp"
+#include "type.hpp"
+
+namespace AltaCore {
+  namespace AST {
+    enum class ClassOperatorType {
+      NONE,
+      Not,
+      Dereference,
+      Reference,
+      Addition,
+      Subtraction,
+      Multiplication,
+      Division,
+      Xor,
+      LeftShift,
+      RightShift,
+      BitAnd,
+      BitOr,
+      BitNot,
+      And,
+      Or,
+      Equality,
+      Inequality,
+      LessThan,
+      GreaterThan,
+      LessThanOrEqualTo,
+      GreaterThanOrEqualTo,
+      Index,
+    };
+    enum class ClassOperatorOrientation {
+      // indicates the operator takes a single argument
+      Unary,
+      // indicates the operator's `this` argument is on the left of the symbol
+      Left,
+      // indicates the operator's `this` argument is on the right of the symbol
+      Right,
+    };
+
+    class ClassOperatorDefinitionStatement: public ClassStatementNode {
+      public:
+        virtual const NodeType nodeType();
+
+        Visibility visibilityModifier = Visibility::Private;
+        ClassOperatorType type = ClassOperatorType::NONE;
+        ClassOperatorOrientation orientation = ClassOperatorOrientation::Unary;
+
+        std::shared_ptr<BlockNode> block = nullptr;
+        std::shared_ptr<Type> returnType = nullptr;
+        std::shared_ptr<Type> argumentType = nullptr;
+
+        ClassOperatorDefinitionStatement(Visibility visibilityModifier);
+
+        ALTACORE_AST_DETAIL_NO_BODY_OPT(ClassOperatorDefinitionStatement);
+        ALTACORE_AST_INFO_DETAIL(ClassOperatorDefinitionStatement);
+        ALTACORE_AST_VALIDATE;
+    };
+  };
+};
+
+#endif // ALTACORE_AST_CLASS_OPERATOR_DEFNITION_STATEMENT_HPP

--- a/include/altacore/ast/class-operator-definition-statement.hpp
+++ b/include/altacore/ast/class-operator-definition-statement.hpp
@@ -7,39 +7,10 @@
 
 namespace AltaCore {
   namespace AST {
-    enum class ClassOperatorType {
-      NONE,
-      Not,
-      Dereference,
-      Reference,
-      Addition,
-      Subtraction,
-      Multiplication,
-      Division,
-      Xor,
-      LeftShift,
-      RightShift,
-      BitAnd,
-      BitOr,
-      BitNot,
-      And,
-      Or,
-      Equality,
-      Inequality,
-      LessThan,
-      GreaterThan,
-      LessThanOrEqualTo,
-      GreaterThanOrEqualTo,
-      Index,
-    };
-    enum class ClassOperatorOrientation {
-      // indicates the operator takes a single argument
-      Unary,
-      // indicates the operator's `this` argument is on the left of the symbol
-      Left,
-      // indicates the operator's `this` argument is on the right of the symbol
-      Right,
-    };
+    using Shared::ClassOperatorType;
+    using Shared::ClassOperatorOrientation;
+    using Shared::ClassOperatorType_names;
+    using Shared::ClassOperatorOrientation_names;
 
     class ClassOperatorDefinitionStatement: public ClassStatementNode {
       public:

--- a/include/altacore/det/class.hpp
+++ b/include/altacore/det/class.hpp
@@ -57,6 +57,8 @@ namespace AltaCore {
 
         std::shared_ptr<Function> findFromCast(const Type& target);
         std::shared_ptr<Function> findToCast(const Type& target);
+
+        std::shared_ptr<Function> findOperator(const Shared::ClassOperatorType type, const Shared::ClassOperatorOrientation orient, std::shared_ptr<Type> argType = nullptr) const;
     };
   };
 };

--- a/include/altacore/det/class.hpp
+++ b/include/altacore/det/class.hpp
@@ -41,6 +41,7 @@ namespace AltaCore {
         std::vector<std::shared_ptr<Variable>> itemsToCopy;
         std::vector<std::shared_ptr<Function>> fromCasts;
         std::vector<std::shared_ptr<Function>> toCasts;
+        std::vector<std::shared_ptr<Function>> operators;
 
         std::vector<std::shared_ptr<Type>> genericArguments;
 

--- a/include/altacore/det/function.hpp
+++ b/include/altacore/det/function.hpp
@@ -37,6 +37,9 @@ namespace AltaCore {
         bool isAccessor = false;
         bool isDestructor = false;
         bool isLambda = false;
+        bool isOperator = false;
+        Shared::ClassOperatorType operatorType = Shared::ClassOperatorType::NONE;
+        Shared::ClassOperatorOrientation orientation = Shared::ClassOperatorOrientation::Unary;
 
         // only used for lambdas
         std::vector<std::shared_ptr<Variable>> referencedVariables;

--- a/include/altacore/detail-handles.hpp
+++ b/include/altacore/detail-handles.hpp
@@ -136,14 +136,24 @@ namespace AltaCore {
       ALTACORE_DH_CTOR(BinaryOperation, ExpressionNode);
 
       Shared::OperatorType type = Shared::OperatorType::Addition;
+      Shared::ClassOperatorType commonType = Shared::ClassOperatorType::NONE;
       std::shared_ptr<ExpressionNode> left = nullptr;
       std::shared_ptr<ExpressionNode> right = nullptr;
+
+      std::shared_ptr<DET::Type> leftType = nullptr;
+      std::shared_ptr<DET::Type> rightType = nullptr;
+      std::shared_ptr<DET::Function> operatorMethod = nullptr;
+      std::shared_ptr<DET::Type> commonOperandType = nullptr;
     };
     class UnaryOperation: public ExpressionNode {
       ALTACORE_DH_CTOR(UnaryOperation, ExpressionNode);
 
       Shared::UOperatorType type = Shared::UOperatorType::Not;
+      Shared::ClassOperatorType commonType = Shared::ClassOperatorType::NONE;
       std::shared_ptr<ExpressionNode> target = nullptr;
+
+      std::shared_ptr<DET::Type> targetType = nullptr;
+      std::shared_ptr<DET::Function> operatorMethod = nullptr;
     };
     class BlockNode: public StatementNode {
       ALTACORE_DH_CTOR(BlockNode, StatementNode);
@@ -239,6 +249,8 @@ namespace AltaCore {
       std::shared_ptr<BlockNode> block = nullptr;
       std::shared_ptr<Type> returnType = nullptr;
       std::shared_ptr<Type> argumentType = nullptr;
+
+      std::shared_ptr<DET::Function> method = nullptr;
     };
     class ConditionalExpression: public ExpressionNode {
       ALTACORE_DH_CTOR(ConditionalExpression, ExpressionNode);

--- a/include/altacore/detail-handles.hpp
+++ b/include/altacore/detail-handles.hpp
@@ -233,6 +233,13 @@ namespace AltaCore {
       bool isDefaultCopyConstructor = false;
       bool isCastConstructor = false;
     };
+    class ClassOperatorDefinitionStatement: public ClassStatementNode {
+      ALTACORE_DH_CTOR(ClassOperatorDefinitionStatement, ClassStatementNode);
+
+      std::shared_ptr<BlockNode> block = nullptr;
+      std::shared_ptr<Type> returnType = nullptr;
+      std::shared_ptr<Type> argumentType = nullptr;
+    };
     class ConditionalExpression: public ExpressionNode {
       ALTACORE_DH_CTOR(ConditionalExpression, ExpressionNode);
 

--- a/include/altacore/detail-handles.hpp
+++ b/include/altacore/detail-handles.hpp
@@ -111,6 +111,11 @@ namespace AltaCore {
       std::shared_ptr<ExpressionNode> target = nullptr;
       std::shared_ptr<ExpressionNode> value = nullptr;
       Shared::AssignmentType type = Shared::AssignmentType::Simple;
+      Shared::ClassOperatorType commonType = Shared::ClassOperatorType::NONE;
+
+      std::shared_ptr<DET::Type> targetType = nullptr;
+      std::shared_ptr<DET::Type> valueType = nullptr;
+      std::shared_ptr<DET::Function> operatorMethod = nullptr;
 
       bool strict = false;
 
@@ -440,6 +445,10 @@ namespace AltaCore {
 
       std::shared_ptr<ExpressionNode> target = nullptr;
       std::shared_ptr<ExpressionNode> index = nullptr;
+
+      std::shared_ptr<DET::Type> targetType = nullptr;
+      std::shared_ptr<DET::Type> indexType = nullptr;
+      std::shared_ptr<DET::Function> operatorMethod = nullptr;
     };
     class SuperClassFetch: public ExpressionNode {
       ALTACORE_DH_CTOR(SuperClassFetch, ExpressionNode);

--- a/include/altacore/lexer.hpp
+++ b/include/altacore/lexer.hpp
@@ -29,6 +29,7 @@ namespace AltaCore {
       Character,
       Code,
       PreprocessorSubstitution,
+      SpecialIdentifier,
       // </special-rules>
 
       // <multi-character-rules>
@@ -80,7 +81,6 @@ namespace AltaCore {
       Tilde,
       Caret,
       Pipe,
-      DollarSign,
 
       LAST, // always keep this as last, it counts the number of items in the enum
     };
@@ -89,6 +89,7 @@ namespace AltaCore {
     static const char* const TokenType_simpleCharacters[] = {
       "",
 
+      "",
       "",
       "",
       "",
@@ -146,7 +147,6 @@ namespace AltaCore {
       "~",
       "^",
       "|",
-      "$",
 
       "",
     };
@@ -163,6 +163,7 @@ namespace AltaCore {
       "Character",
       "Code",
       "Preprocessor substitution",
+      "Special identifier",
 
       "Equality",
       "And",

--- a/include/altacore/parser.hpp
+++ b/include/altacore/parser.hpp
@@ -198,6 +198,7 @@ namespace AltaCore {
       Bitfield,
       Lambda,
       SpecialFetch,
+      OperatorDefinition,
     };
 
     enum class PrepoRuleType {

--- a/include/altacore/shared.hpp
+++ b/include/altacore/shared.hpp
@@ -69,6 +69,124 @@ namespace AltaCore {
       BitwiseOr,
       BitwiseXor,
     };
+
+    enum class ClassOperatorType {
+      NONE,
+      Not,
+      Dereference,
+      Reference,
+      Addition,
+      Subtraction,
+      Multiplication,
+      Division,
+      Xor,
+      LeftShift,
+      RightShift,
+      BitAnd,
+      BitOr,
+      BitNot,
+      And,
+      Or,
+      Equality,
+      Inequality,
+      LessThan,
+      GreaterThan,
+      LessThanOrEqualTo,
+      GreaterThanOrEqualTo,
+      Index,
+    };
+
+    static const char* const ClassOperatorType_names[] = {
+      "NONE",
+      "Not",
+      "Dereference",
+      "Reference",
+      "Addition",
+      "Subtraction",
+      "Multiplication",
+      "Division",
+      "Xor",
+      "LeftShift",
+      "RightShift",
+      "BitAnd",
+      "BitOr",
+      "BitNot",
+      "And",
+      "Or",
+      "Equality",
+      "Inequality",
+      "LessThan",
+      "GreaterThan",
+      "LessThanOrEqualTo",
+      "GreaterThanOrEqualTo",
+      "Index",
+    };
+
+    enum class ClassOperatorOrientation {
+      // indicates the operator takes a single argument
+      Unary,
+      // indicates the operator's `this` argument is on the left of the symbol
+      Left,
+      // indicates the operator's `this` argument is on the right of the symbol
+      Right,
+    };
+
+    static const char* const ClassOperatorOrientation_names[] = {
+      "Unary",
+      "Left",
+      "Right",
+    };
+
+    // RTC = regular-to-class
+    static inline ClassOperatorType convertOperatorTypeRTC(OperatorType op) {
+      ClassOperatorType result = ClassOperatorType::NONE;
+      #define AC_OP_CONV(source, dest) if (op == OperatorType::source) {\
+                                         return ClassOperatorType::dest;\
+                                       }
+      #define AC_OP_DCONV(name) AC_OP_CONV(name, name)
+
+      AC_OP_DCONV(Addition);
+      AC_OP_DCONV(Subtraction);
+      AC_OP_DCONV(Multiplication);
+      AC_OP_DCONV(Division);
+
+      AC_OP_DCONV(LeftShift);
+      AC_OP_DCONV(RightShift);
+
+      AC_OP_CONV(BitwiseAnd, BitAnd);
+      AC_OP_CONV(BitwiseOr, BitOr);
+      AC_OP_CONV(BitwiseXor, Xor);
+
+      AC_OP_CONV(EqualTo, Equality);
+      AC_OP_CONV(NotEqualTo, Inequality);
+
+      AC_OP_DCONV(LessThan);
+      AC_OP_DCONV(LessThanOrEqualTo);
+      AC_OP_DCONV(GreaterThan);
+      AC_OP_DCONV(GreaterThanOrEqualTo);
+
+      AC_OP_CONV(LogicalAnd, And);
+      AC_OP_CONV(LogicalOr, Or);
+
+      #undef AC_OP_CONV
+      #undef AC_OP_DCONV
+      return ClassOperatorType::NONE;
+    };
+    // RTC = regular-to-class
+    static inline ClassOperatorType convertOperatorTypeRTC(UOperatorType op) {
+      ClassOperatorType result = ClassOperatorType::NONE;
+      #define AC_OP_CONV(source, dest) if (op == UOperatorType::source) {\
+                                         return ClassOperatorType::dest;\
+                                       }
+      #define AC_OP_DCONV(name) AC_OP_CONV(name, name)
+
+      AC_OP_DCONV(Not);
+      AC_OP_CONV(BitwiseNot, BitNot);
+
+      #undef AC_OP_CONV
+      #undef AC_OP_DCONV
+      return ClassOperatorType::NONE;
+    };
   };
 };
 

--- a/include/altacore/shared.hpp
+++ b/include/altacore/shared.hpp
@@ -79,6 +79,7 @@ namespace AltaCore {
       Subtraction,
       Multiplication,
       Division,
+      Modulo,
       Xor,
       LeftShift,
       RightShift,
@@ -94,6 +95,16 @@ namespace AltaCore {
       LessThanOrEqualTo,
       GreaterThanOrEqualTo,
       Index,
+      AdditionAssignment,
+      SubtractionAssignment,
+      MultiplicationAssignment,
+      DivisionAssignment,
+      ModuloAssignment,
+      LeftShiftAssignment,
+      RightShiftAssignment,
+      BitwiseAndAssignment,
+      BitwiseOrAssignment,
+      BitwiseXorAssignment,
     };
 
     static const char* const ClassOperatorType_names[] = {
@@ -105,6 +116,7 @@ namespace AltaCore {
       "Subtraction",
       "Multiplication",
       "Division",
+      "Modulo",
       "Xor",
       "LeftShift",
       "RightShift",
@@ -120,6 +132,16 @@ namespace AltaCore {
       "LessThanOrEqualTo",
       "GreaterThanOrEqualTo",
       "Index",
+      "AdditionAssignment",
+      "SubtractionAssignment",
+      "MultiplicationAssignment",
+      "DivisionAssignment",
+      "ModuloAssignment",
+      "LeftShiftAssignment",
+      "RightShiftAssignment",
+      "BitwiseAndAssignment",
+      "BitwiseOrAssignment",
+      "BitwiseXorAssignment",
     };
 
     enum class ClassOperatorOrientation {
@@ -149,6 +171,7 @@ namespace AltaCore {
       AC_OP_DCONV(Subtraction);
       AC_OP_DCONV(Multiplication);
       AC_OP_DCONV(Division);
+      AC_OP_DCONV(Modulo);
 
       AC_OP_DCONV(LeftShift);
       AC_OP_DCONV(RightShift);
@@ -185,6 +208,29 @@ namespace AltaCore {
 
       #undef AC_OP_CONV
       #undef AC_OP_DCONV
+      return ClassOperatorType::NONE;
+    };
+    // RTC = regular-to-class
+    static inline ClassOperatorType convertOperatorTypeRTC(AssignmentType op) {
+      ClassOperatorType result = ClassOperatorType::NONE;
+      #define AC_OP_CONV(source, dest) if (op == AssignmentType::source) {\
+                                         return ClassOperatorType::dest;\
+                                       }
+      #define AC_OP_ACONV(name) AC_OP_CONV(name, name##Assignment)
+
+      AC_OP_ACONV(Addition);
+      AC_OP_ACONV(Subtraction);
+      AC_OP_ACONV(Multiplication);
+      AC_OP_ACONV(Division);
+      AC_OP_ACONV(Modulo);
+      AC_OP_ACONV(LeftShift);
+      AC_OP_ACONV(RightShift);
+      AC_OP_ACONV(BitwiseAnd);
+      AC_OP_ACONV(BitwiseOr);
+      AC_OP_ACONV(BitwiseXor);
+
+      #undef AC_OP_CONV
+      #undef AC_OP_ACONV
       return ClassOperatorType::NONE;
     };
   };

--- a/src/ast/accessor.cpp
+++ b/src/ast/accessor.cpp
@@ -262,11 +262,11 @@ void AltaCore::AST::Accessor::narrowTo(std::shared_ptr<DH::Accessor> info, std::
     }
   }
   if (info->narrowedTo) {
-    if (auto parentScope = info->narrowedTo->parentScope.lock()) {
-      if (auto parentModule = parentScope->parentModule.lock()) {
+    //if (auto parentScope = info->narrowedTo->parentScope.lock()) {
+      //if (auto parentModule = parentScope->parentModule.lock()) {
         info->inputScope->hoist(info->narrowedTo);
-      }
-    }
+      //}
+    //}
   }
 };
 void AltaCore::AST::Accessor::narrowTo(std::shared_ptr<DH::Accessor> info, size_t i) {
@@ -276,11 +276,11 @@ void AltaCore::AST::Accessor::narrowTo(std::shared_ptr<DH::Accessor> info, size_
   info->narrowedTo = info->items[i];
   info->narrowedToIndex = i;
   if (info->narrowedTo) {
-    if (auto parentScope = info->narrowedTo->parentScope.lock()) {
-      if (auto parentModule = parentScope->parentModule.lock()) {
+    //if (auto parentScope = info->narrowedTo->parentScope.lock()) {
+      //if (auto parentModule = parentScope->parentModule.lock()) {
         info->inputScope->hoist(info->narrowedTo);
-      }
-    }
+      //}
+    //}
   }
 };
 void AltaCore::AST::Accessor::widen(std::shared_ptr<DH::Accessor> info) {

--- a/src/ast/assignment-expression.cpp
+++ b/src/ast/assignment-expression.cpp
@@ -23,21 +23,7 @@ ALTACORE_AST_DETAIL_D(AssignmentExpression) {
   info->commonType = Shared::convertOperatorTypeRTC(info->type);
 
   if (info->targetType->klass && info->targetType->pointerLevel() < 1) {
-    size_t highestCompat = 0;
-    size_t compatIdx = SIZE_MAX;
-    for (size_t i = 0; i < info->targetType->klass->operators.size(); ++i) {
-      auto& op = info->targetType->klass->operators[i];
-      if (op->operatorType != info->commonType) continue;
-      if (op->orientation != Shared::ClassOperatorOrientation::Left) continue;
-      auto compat = op->parameterVariables.front()->type->compatiblity(*info->valueType);
-      if (compat > highestCompat) {
-        highestCompat = compat;
-        compatIdx = i;
-      }
-    }
-    if (highestCompat != 0) {
-      info->operatorMethod = info->targetType->klass->operators[compatIdx];
-    }
+    info->operatorMethod = info->targetType->klass->findOperator(info->commonType, Shared::ClassOperatorOrientation::Left, info->valueType);
   }
 
   if (info->operatorMethod) {

--- a/src/ast/assignment-expression.cpp
+++ b/src/ast/assignment-expression.cpp
@@ -16,7 +16,34 @@ ALTACORE_AST_DETAIL_D(AssignmentExpression) {
   info->target = target->fullDetail(scope);
   info->value = value->fullDetail(scope);
   info->type = type;
-  
+
+  info->targetType = DET::Type::getUnderlyingType(info->target.get());
+  info->valueType = DET::Type::getUnderlyingType(info->value.get());
+
+  info->commonType = Shared::convertOperatorTypeRTC(info->type);
+
+  if (info->targetType->klass && info->targetType->pointerLevel() < 1) {
+    size_t highestCompat = 0;
+    size_t compatIdx = SIZE_MAX;
+    for (size_t i = 0; i < info->targetType->klass->operators.size(); ++i) {
+      auto& op = info->targetType->klass->operators[i];
+      if (op->operatorType != info->commonType) continue;
+      if (op->orientation != Shared::ClassOperatorOrientation::Left) continue;
+      auto compat = op->parameterVariables.front()->type->compatiblity(*info->valueType);
+      if (compat > highestCompat) {
+        highestCompat = compat;
+        compatIdx = i;
+      }
+    }
+    if (highestCompat != 0) {
+      info->operatorMethod = info->targetType->klass->operators[compatIdx];
+    }
+  }
+
+  if (info->operatorMethod) {
+    info->inputScope->hoist(info->operatorMethod);
+  }
+
   for (auto& attr: attributes) {
     info->attributes.push_back(attr->fullDetail(info->inputScope, shared_from_this(), info));
   }
@@ -29,19 +56,18 @@ ALTACORE_AST_VALIDATE_D(AssignmentExpression) {
   target->validate(stack, info->target);
   value->validate(stack, info->value);
 
-  auto targetType = DET::Type::getUnderlyingType(info->target.get());
-  auto valueType = DET::Type::getUnderlyingType(info->value.get());
-  
-  if (targetType->modifiers.size() > 0 && targetType->modifiers.front() & (uint8_t)Shared::TypeModifierFlag::Constant) {
-    ALTACORE_VALIDATION_ERROR("can't assign to a constant");
-  }
+  if (!info->operatorMethod) {
+    if (info->targetType->modifiers.size() > 0 && info->targetType->modifiers.front() & (uint8_t)Shared::TypeModifierFlag::Constant) {
+      ALTACORE_VALIDATION_ERROR("can't assign to a constant");
+    }
 
-  if (!targetType->isCompatibleWith(*valueType)) {
-    ALTACORE_VALIDATION_ERROR("source type is not compatible with the destination type for assignment expression");
-  }
+    if (!info->targetType->isCompatibleWith(*info->valueType)) {
+      ALTACORE_VALIDATION_ERROR("source type is not compatible with the destination type for assignment expression");
+    }
 
-  if (type != AssignmentType::Simple && !targetType->isNative) {
-    ALTACORE_VALIDATION_ERROR("cannot perform compound addition on non-native types");
+    if (type != AssignmentType::Simple && !info->targetType->isNative) {
+      ALTACORE_VALIDATION_ERROR("cannot perform compound addition on non-native types");
+    }
   }
 
   ALTACORE_VS_E;

--- a/src/ast/binary-operation.cpp
+++ b/src/ast/binary-operation.cpp
@@ -23,7 +23,7 @@ ALTACORE_AST_DETAIL_D(BinaryOperation) {
   info->rightType = DET::Type::getUnderlyingType(info->right.get());
   info->commonType = Shared::convertOperatorTypeRTC(info->type);
 
-  if (info->leftType->klass) {
+  if (info->leftType->klass && info->leftType->pointerLevel() < 1) {
     size_t highestCompat = 0;
     size_t compatIdx = SIZE_MAX;
     for (size_t i = 0; i < info->leftType->klass->operators.size(); ++i) {
@@ -41,7 +41,7 @@ ALTACORE_AST_DETAIL_D(BinaryOperation) {
     }
   }
 
-  if (info->operatorMethod == nullptr && info->rightType->klass) {
+  if (info->operatorMethod == nullptr && info->rightType->klass && info->rightType->pointerLevel() < 1) {
     size_t highestCompat = 0;
     size_t compatIdx = SIZE_MAX;
     for (size_t i = 0; i < info->rightType->klass->operators.size(); ++i) {

--- a/src/ast/binary-operation.cpp
+++ b/src/ast/binary-operation.cpp
@@ -97,6 +97,8 @@ ALTACORE_AST_DETAIL_D(BinaryOperation) {
         }
       }
     }
+  } else {
+    info->inputScope->hoist(info->operatorMethod);
   }
 
   return info;

--- a/src/ast/binary-operation.cpp
+++ b/src/ast/binary-operation.cpp
@@ -24,39 +24,11 @@ ALTACORE_AST_DETAIL_D(BinaryOperation) {
   info->commonType = Shared::convertOperatorTypeRTC(info->type);
 
   if (info->leftType->klass && info->leftType->pointerLevel() < 1) {
-    size_t highestCompat = 0;
-    size_t compatIdx = SIZE_MAX;
-    for (size_t i = 0; i < info->leftType->klass->operators.size(); ++i) {
-      auto& op = info->leftType->klass->operators[i];
-      if (op->operatorType != info->commonType) continue;
-      if (op->orientation != Shared::ClassOperatorOrientation::Left) continue;
-      auto compat = op->parameterVariables.front()->type->compatiblity(*info->rightType);
-      if (compat > highestCompat) {
-        highestCompat = compat;
-        compatIdx = i;
-      }
-    }
-    if (highestCompat != 0) {
-      info->operatorMethod = info->leftType->klass->operators[compatIdx];
-    }
+    info->operatorMethod = info->leftType->klass->findOperator(info->commonType, Shared::ClassOperatorOrientation::Left, info->rightType);
   }
 
   if (info->operatorMethod == nullptr && info->rightType->klass && info->rightType->pointerLevel() < 1) {
-    size_t highestCompat = 0;
-    size_t compatIdx = SIZE_MAX;
-    for (size_t i = 0; i < info->rightType->klass->operators.size(); ++i) {
-      auto& op = info->rightType->klass->operators[i];
-      if (op->operatorType != info->commonType) continue;
-      if (op->orientation != Shared::ClassOperatorOrientation::Right) continue;
-      auto compat = op->parameterVariables.front()->type->compatiblity(*info->leftType);
-      if (compat > highestCompat) {
-        highestCompat = compat;
-        compatIdx = i;
-      }
-    }
-    if (highestCompat != 0) {
-      info->operatorMethod = info->rightType->klass->operators[compatIdx];
-    }
+    info->operatorMethod = info->rightType->klass->findOperator(info->commonType, Shared::ClassOperatorOrientation::Right, info->leftType);
   }
 
   if (info->operatorMethod == nullptr) {

--- a/src/ast/class-definition-node.cpp
+++ b/src/ast/class-definition-node.cpp
@@ -56,6 +56,10 @@ namespace AltaCoreClassHelpers {
             } else {
               throw AltaCore::Errors::ValidationError("impossible detailing error: unrecognized special method type", self->position);
             }
+          } else if (stmt->nodeType() == NodeType::ClassOperatorDefinitionStatement) {
+            auto op = std::dynamic_pointer_cast<ClassOperatorDefinitionStatement>(stmt);
+            auto opDet = std::dynamic_pointer_cast<DH::ClassOperatorDefinitionStatement>(det);
+            info->klass->operators.push_back(opDet->method);
           }
         }
       } else {

--- a/src/ast/class-instantiation-expression.cpp
+++ b/src/ast/class-instantiation-expression.cpp
@@ -61,6 +61,7 @@ ALTACORE_AST_DETAIL_D(ClassInstantiationExpression) {
     info->constructor = info->klass->constructors[indexMap[index]];
     info->adjustedArguments = adjArgs;
     info->argumentMap = argMap;
+    info->inputScope->hoist(info->constructor);
   } else {
     ALTACORE_DETAILING_ERROR("unable to find suitable constructor");
   }

--- a/src/ast/class-operator-definition-statement.cpp
+++ b/src/ast/class-operator-definition-statement.cpp
@@ -1,0 +1,25 @@
+#include "../../include/altacore/ast/class-operator-definition-statement.hpp"
+#include "../../include/altacore/det/type.hpp"
+
+const AltaCore::AST::NodeType AltaCore::AST::ClassOperatorDefinitionStatement::nodeType() {
+  return NodeType::ClassOperatorDefinitionStatement;
+};
+
+AltaCore::AST::ClassOperatorDefinitionStatement::ClassOperatorDefinitionStatement(AltaCore::AST::Visibility _visibilityModifier):
+  visibilityModifier(_visibilityModifier)
+  {};
+
+ALTACORE_AST_DETAIL_NO_BODY_OPT_D(ClassOperatorDefinitionStatement) {
+  ALTACORE_MAKE_DH(ClassOperatorDefinitionStatement);
+  return detail(info, noBody);
+};
+
+ALTACORE_AST_VALIDATE_D(ClassOperatorDefinitionStatement) {
+  ALTACORE_VS_S(ClassOperatorDefinitionStatement);
+  ALTACORE_VS_E;
+};
+
+ALTACORE_AST_INFO_DETAIL_D(ClassOperatorDefinitionStatement) {
+  ALTACORE_CAST_DH(ClassOperatorDefinitionStatement);
+  return info;
+};

--- a/src/ast/class-operator-definition-statement.cpp
+++ b/src/ast/class-operator-definition-statement.cpp
@@ -45,11 +45,12 @@ ALTACORE_AST_INFO_DETAIL_D(ClassOperatorDefinitionStatement) {
 
   if (!info->method->returnType) {
     std::vector<std::tuple<std::string, std::shared_ptr<DET::Type>, bool, std::string>> params;
-    if (orientation != ClassOperatorOrientation::Unary) {
+    bool hasArg = type == ClassOperatorType::Index || orientation != ClassOperatorOrientation::Unary;
+    if (hasArg) {
       params.push_back(std::make_tuple(orientation == ClassOperatorOrientation::Left ? "$right" : "$left", info->argumentType->type, false, "N/A"));
     }
     info->method->recreate(params, info->returnType->type);
-    if (orientation != ClassOperatorOrientation::Unary) {
+    if (hasArg) {
       auto inputAlias = std::make_shared<DET::Alias>("$", info->method->parameterVariables.front(), info->method->scope);
       info->method->scope->items.push_back(inputAlias);
     }

--- a/src/ast/class-operator-definition-statement.cpp
+++ b/src/ast/class-operator-definition-statement.cpp
@@ -21,5 +21,43 @@ ALTACORE_AST_VALIDATE_D(ClassOperatorDefinitionStatement) {
 
 ALTACORE_AST_INFO_DETAIL_D(ClassOperatorDefinitionStatement) {
   ALTACORE_CAST_DH(ClassOperatorDefinitionStatement);
+
+  if (!info->method) {
+    info->method = DET::Function::create(info->inputScope, std::string("@operator@") + ClassOperatorType_names[(size_t)type] + "@" + Shared::ClassOperatorOrientation_names[(size_t)orientation], {}, nullptr);
+    info->method->visibility = visibilityModifier;
+    info->method->isMethod = true;
+    info->method->isOperator = true;
+    info->method->operatorType = type;
+    info->method->orientation = orientation;
+    auto klass = info->inputScope->parentClass.lock();
+    info->method->parentClassType = std::make_shared<DET::Type>(klass, std::vector<uint8_t> { (uint8_t)TypeModifierFlag::Reference });
+  }
+
+  std::vector<std::tuple<std::string, std::shared_ptr<DET::Type>, bool, std::string>> params;
+
+  if (!info->argumentType && argumentType) {
+    info->argumentType = argumentType->fullDetail(info->method->scope);
+  }
+
+  if (!info->returnType) {
+    info->returnType = returnType->fullDetail(info->method->scope);
+  }
+
+  if (!info->method->returnType) {
+    std::vector<std::tuple<std::string, std::shared_ptr<DET::Type>, bool, std::string>> params;
+    if (orientation != ClassOperatorOrientation::Unary) {
+      params.push_back(std::make_tuple(orientation == ClassOperatorOrientation::Left ? "$right" : "$left", info->argumentType->type, false, "N/A"));
+    }
+    info->method->recreate(params, info->returnType->type);
+    if (orientation != ClassOperatorOrientation::Unary) {
+      auto inputAlias = std::make_shared<DET::Alias>("$", info->method->parameterVariables.front(), info->method->scope);
+      info->method->scope->items.push_back(inputAlias);
+    }
+  }
+
+  if (!noBody && !info->block) {
+    info->block = block->fullDetail(info->method->scope);
+  }
+
   return info;
 };

--- a/src/ast/special-fetch-expression.cpp
+++ b/src/ast/special-fetch-expression.cpp
@@ -7,10 +7,10 @@ const AltaCore::AST::NodeType AltaCore::AST::SpecialFetchExpression::nodeType() 
 ALTACORE_AST_DETAIL_D(SpecialFetchExpression) {
   ALTACORE_MAKE_DH(SpecialFetchExpression);
 
-  info->items = info->inputScope->findAll("$", {}, true, info->inputScope);
+  info->items = info->inputScope->findAll(query, {}, true, info->inputScope);
 
   if (info->items.size() < 1) {
-    ALTACORE_DETAILING_ERROR("special fetch used in invalid location (no fetch targets found)");
+    ALTACORE_DETAILING_ERROR("invalid special fetch or special fetch used in invalid location (no fetch targets found)");
   } else if (info->items.size() > 1) {
     ALTACORE_DETAILING_ERROR("impossible special fetch error encountered (multiple fetch targets found)");
   }

--- a/src/ast/subscript-expression.cpp
+++ b/src/ast/subscript-expression.cpp
@@ -25,21 +25,7 @@ ALTACORE_AST_DETAIL_D(SubscriptExpression) {
   info->indexType = DET::Type::getUnderlyingType(info->index.get());
 
   if (info->targetType->klass && info->targetType->pointerLevel() < 1) {
-    size_t highestCompat = 0;
-    size_t compatIdx = SIZE_MAX;
-    for (size_t i = 0; i < info->targetType->klass->operators.size(); ++i) {
-      auto& op = info->targetType->klass->operators[i];
-      if (op->operatorType != Shared::ClassOperatorType::Index) continue;
-      if (op->orientation != Shared::ClassOperatorOrientation::Unary) continue;
-      auto compat = op->parameterVariables.front()->type->compatiblity(*info->indexType);
-      if (compat > highestCompat) {
-        highestCompat = compat;
-        compatIdx = i;
-      }
-    }
-    if (highestCompat != 0) {
-      info->operatorMethod = info->targetType->klass->operators[compatIdx];
-    }
+    info->operatorMethod = info->targetType->klass->findOperator(Shared::ClassOperatorType::Index, Shared::ClassOperatorOrientation::Unary, info->indexType);
   }
 
   if (info->operatorMethod) {

--- a/src/ast/unary-operation.cpp
+++ b/src/ast/unary-operation.cpp
@@ -28,6 +28,10 @@ ALTACORE_AST_DETAIL_D(UnaryOperation) {
     }
   }
 
+  if (info->operatorMethod) {
+    info->inputScope->hoist(info->operatorMethod);
+  }
+
   return info;
 };
 

--- a/src/ast/unary-operation.cpp
+++ b/src/ast/unary-operation.cpp
@@ -20,12 +20,7 @@ ALTACORE_AST_DETAIL_D(UnaryOperation) {
   info->commonType = Shared::convertOperatorTypeRTC(info->type);
 
   if (info->targetType->klass && info->targetType->pointerLevel() < 1) {
-    for (auto& op: info->targetType->klass->operators) {
-      if (op->operatorType != info->commonType) continue;
-      if (op->orientation != Shared::ClassOperatorOrientation::Unary) continue;
-      info->operatorMethod = op;
-      break;
-    }
+    info->operatorMethod = info->targetType->klass->findOperator(info->commonType, Shared::ClassOperatorOrientation::Unary);
   }
 
   if (info->operatorMethod) {

--- a/src/ast/unary-operation.cpp
+++ b/src/ast/unary-operation.cpp
@@ -16,6 +16,18 @@ ALTACORE_AST_DETAIL_D(UnaryOperation) {
   ALTACORE_MAKE_DH(UnaryOperation);
   info->type = type;
   info->target = target->fullDetail(scope);
+  info->targetType = DET::Type::getUnderlyingType(info->target.get());
+  info->commonType = Shared::convertOperatorTypeRTC(info->type);
+
+  if (info->targetType->klass) {
+    for (auto& op: info->targetType->klass->operators) {
+      if (op->operatorType != info->commonType) continue;
+      if (op->orientation != Shared::ClassOperatorOrientation::Unary) continue;
+      info->operatorMethod = op;
+      break;
+    }
+  }
+
   return info;
 };
 

--- a/src/ast/unary-operation.cpp
+++ b/src/ast/unary-operation.cpp
@@ -19,7 +19,7 @@ ALTACORE_AST_DETAIL_D(UnaryOperation) {
   info->targetType = DET::Type::getUnderlyingType(info->target.get());
   info->commonType = Shared::convertOperatorTypeRTC(info->type);
 
-  if (info->targetType->klass) {
+  if (info->targetType->klass && info->targetType->pointerLevel() < 1) {
     for (auto& op: info->targetType->klass->operators) {
       if (op->operatorType != info->commonType) continue;
       if (op->orientation != Shared::ClassOperatorOrientation::Unary) continue;

--- a/src/det/class.cpp
+++ b/src/det/class.cpp
@@ -75,3 +75,32 @@ std::shared_ptr<AltaCore::DET::Function> AltaCore::DET::Class::findToCast(const 
   }
   return nullptr;
 };
+
+std::shared_ptr<AltaCore::DET::Function> AltaCore::DET::Class::findOperator(const Shared::ClassOperatorType type, const Shared::ClassOperatorOrientation orient, std::shared_ptr<Type> argType) const {
+  size_t highestCompat = 0;
+  size_t compatIdx = SIZE_MAX;
+  for (size_t i = 0; i < operators.size(); ++i) {
+    auto& op = operators[i];
+    if (op->operatorType != type) continue;
+    if (op->orientation != orient) continue;
+    if (argType) {
+      auto compat = op->parameterVariables.front()->type->compatiblity(*argType);
+      if (compat > highestCompat) {
+        highestCompat = compat;
+        compatIdx = i;
+      }
+    } else {
+      highestCompat = SIZE_MAX;
+      compatIdx = i;
+      break;
+    }
+  }
+  if (highestCompat != 0) {
+    return operators[compatIdx];
+  }
+  for (auto& parent: parents) {
+    auto func = parent->findOperator(type, orient, argType);
+    if (func) return func;
+  }
+  return nullptr;
+};

--- a/src/det/type.cpp
+++ b/src/det/type.cpp
@@ -52,6 +52,9 @@ std::shared_ptr<AltaCore::DET::Type> AltaCore::DET::Type::getUnderlyingType(Alta
   } else if (auto boolean = dynamic_cast<DH::BooleanLiteralNode*>(expression)) {
     return std::make_shared<Type>(NativeType::Bool, std::vector<uint8_t> { (uint8_t)Modifier::Constant });
   } else if (auto binOp = dynamic_cast<DH::BinaryOperation*>(expression)) {
+    if (binOp->operatorMethod) {
+      return binOp->operatorMethod->returnType;
+    }
     if ((uint8_t)binOp->type <= (uint8_t)Shared::OperatorType::BitwiseXor) {
       return getUnderlyingType(binOp->left.get())->destroyReferences();
     } else {
@@ -106,6 +109,9 @@ std::shared_ptr<AltaCore::DET::Type> AltaCore::DET::Type::getUnderlyingType(Alta
   } else if (auto instOf = dynamic_cast<DH::InstanceofExpression*>(expression)) {
     return std::make_shared<Type>(NativeType::Bool, std::vector<uint8_t> { (uint8_t)Modifier::Constant });
   } else if (auto unary = dynamic_cast<DH::UnaryOperation*>(expression)) {
+    if (unary->operatorMethod) {
+      return unary->operatorMethod->returnType;
+    }
     if (unary->type == Shared::UOperatorType::Not) {
       return std::make_shared<Type>(NativeType::Bool, std::vector<uint8_t> { (uint8_t)Modifier::Constant });
     } else {
@@ -1157,7 +1163,7 @@ size_t AltaCore::DET::Type::compatiblity(const AltaCore::DET::Type& other) const
     }
   }
   if (pointerLevel() == 0 && klass) {
-    if (auto from = klass->findFromCast(*this)) {
+    if (auto from = klass->findFromCast(other)) {
       return 2;
     }
   }

--- a/src/det/type.cpp
+++ b/src/det/type.cpp
@@ -1294,7 +1294,7 @@ bool AltaCore::DET::Type::commonCompatiblity(const AltaCore::DET::Type& other, b
 
   if (!strict) {
     if (other.pointerLevel() == 0 && other.klass && other.klass->findToCast(*this)) return true;
-    if (pointerLevel() == 0 && klass && klass->findFromCast(*this)) return true;
+    if (pointerLevel() == 0 && klass && klass->findFromCast(other)) return true;
   }
 
   if (isOptional && other.isAny && other.pointerLevel() == 1) return true;
@@ -1419,7 +1419,7 @@ bool AltaCore::DET::Type::isCompatibleWith(const AltaCore::DET::Type& other) con
   if (isExactlyCompatibleWith(other)) return true;
 
   if (other.pointerLevel() == 0 && other.klass && other.klass->findToCast(*this)) return true;
-  if (pointerLevel() == 0 && klass && klass->findFromCast(*this)) return true;
+  if (pointerLevel() == 0 && klass && klass->findFromCast(other)) return true;
 
   // integers can be converted to pointers
   if (other.isNative && other.pointerLevel() < 1 && pointerLevel() > 0) return true;

--- a/src/det/type.cpp
+++ b/src/det/type.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<AltaCore::DET::Type> AltaCore::DET::Type::getUnderlyingType(Alta
   } else if (auto varDef = dynamic_cast<DH::VariableDefinitionExpression*>(expression)) {
     return std::dynamic_pointer_cast<Type>(varDef->variable->type->clone())->reference();
   } else if (auto assign = dynamic_cast<DH::AssignmentExpression*>(expression)) {
-    return getUnderlyingType(assign->target.get())->reference();
+    return assign->operatorMethod ? assign->operatorMethod->returnType : getUnderlyingType(assign->target.get())->reference();
   } else if (auto fetch = dynamic_cast<DH::Fetch*>(expression)) {
     if (!fetch->narrowedTo) {
       if (fetch->readAccessor) {
@@ -103,7 +103,7 @@ std::shared_ptr<AltaCore::DET::Type> AltaCore::DET::Type::getUnderlyingType(Alta
   } else if (auto chara = dynamic_cast<DH::CharacterLiteralNode*>(expression)) {
     return std::make_shared<Type>(NativeType::Byte, std::vector<uint8_t> { (uint8_t)Modifier::Constant });
   } else if (auto subs = dynamic_cast<DH::SubscriptExpression*>(expression)) {
-    return getUnderlyingType(subs->target.get())->follow();
+    return subs->operatorMethod ? subs->operatorMethod->returnType : getUnderlyingType(subs->target.get())->follow();
   } else if (auto sc = dynamic_cast<DH::SuperClassFetch*>(expression)) {
     return std::make_shared<Type>(sc->superclass, std::vector<uint8_t> { (uint8_t)Modifier::Reference });
   } else if (auto instOf = dynamic_cast<DH::InstanceofExpression*>(expression)) {

--- a/src/det/type.cpp
+++ b/src/det/type.cpp
@@ -1065,6 +1065,23 @@ auto AltaCore::DET::Type::findCast(std::shared_ptr<Type> from, std::shared_ptr<T
     AC_TO_LOOP_END;
 
     AC_TO_LOOP;
+      if (
+        from->referenceLevel() == 0 &&
+        to->referenceLevel() == 0 &&
+        from->pointerLevel() == 0 &&
+        to->pointerLevel() > 0 &&
+        from->isNative &&
+        (
+          from->nativeTypeName == NT::Integer ||
+          from->nativeTypeName == NT::Byte
+        )
+      ) {
+        AC_RETURN_INDEX;
+        return { CC(CCT::SimpleCoercion, to), CC(CCT::Destination) };
+      }
+    AC_TO_LOOP_END;
+
+    AC_TO_LOOP;
       if (from->referenceLevel() == 0 && from->pointerLevel() > 0 && to->indirectionLevel() == 0 && to->isNative && to->nativeTypeName == NT::Bool) {
         AC_RETURN_INDEX;
         return { CC(CCT::Destination, SCT::TestPointer) };

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -180,6 +180,20 @@ namespace AltaCore {
             return true;
           }
         } break;
+        case TokenType::SpecialIdentifier: {
+          if (first) {
+            return character == '$';
+          }
+
+          if (
+            character == '_' ||
+            (character >= 'a' && character <= 'z') ||
+            (character >= 'A' && character <= 'Z') ||
+            (character >= '0' && character <= '9')
+          ) {
+            return true;
+          }
+        } break;
         default: {
           *contigious = true;
           auto string = TokenType_simpleCharacters[(int)rule];

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1496,7 +1496,7 @@ namespace AltaCore {
               type = AT::BitwiseAnd;
             } else if (expect(TokenType::BitwiseOrEquals)) {
               type = AT::BitwiseOr;
-            } else if (expect(TokenType::BitwiseAndEquals)) {
+            } else if (expect(TokenType::BitwiseXorEquals)) {
               type = AT::BitwiseXor;
             } else {
               restoreState();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2171,7 +2171,8 @@ namespace AltaCore {
             ACP_RULE_LIST(
               RuleType::ClassMember,
               RuleType::ClassSpecialMethod,
-              RuleType::ClassMethod
+              RuleType::ClassMethod,
+              RuleType::OperatorDefinition
             );
           }
 
@@ -3412,11 +3413,172 @@ namespace AltaCore {
           }
           #undef LAMBDA_RESTORE
         } else if (rule == RuleType::SpecialFetch) {
-          if (!expect(TokenType::DollarSign)) ACP_NOT_OK;
+          auto id = expect(TokenType::SpecialIdentifier);
+          if (!id) ACP_NOT_OK;
 
           auto special = std::make_shared<AST::SpecialFetchExpression>();
+          special->query = id.raw;
 
           ACP_NODE(special);
+        } else if (rule == RuleType::OperatorDefinition) {
+          if (state.internalIndex == 0) {
+            state.internalIndex = 1;
+            ACP_RULE(Attribute);
+          } else if (state.internalIndex == 1) {
+            if (exps.back()) ACP_RULE(Attribute);
+
+            exps.pop_back();
+
+            auto visibilityMod = expectModifier(ModifierTargetType::ClassStatement);
+            if (!visibilityMod) ACP_NOT_OK;
+
+            ruleNode = std::make_shared<AST::ClassOperatorDefinitionStatement>(AST::parseVisibility(*visibilityMod));
+
+            // optional, but make sure we expect a closing parenthesis later
+            state.internalValue = !!expect(TokenType::OpeningParenthesis);
+
+            state.internalIndex = 2;
+            ACP_RULE(NullRule);
+          } else if (state.internalIndex == 2) {
+            using COT = AST::ClassOperatorType;
+            using COO = AST::ClassOperatorOrientation;
+            COT type = COT::NONE;
+            COO orient = COO::Unary;
+            auto op = std::dynamic_pointer_cast<AST::ClassOperatorDefinitionStatement>(ruleNode);
+            if (expect(TokenType::ExclamationMark)) {
+              type = COT::Not;
+            } else if (expect(TokenType::Asterisk)) {
+              type = COT::Dereference;
+            } else if (expect(TokenType::Ampersand)) {
+              type = COT::Reference;
+            } else if (expectKeyword("this")) {
+              if (expect(TokenType::OpeningSquareBracket)) {
+                state.internalIndex = 10;
+                op->orientation = COO::Unary;
+                ACP_RULE(Type);
+              } else {
+                op->orientation = COO::Left;
+                state.internalIndex = 6;
+                ACP_RULE(NullRule);
+              }
+            } else {
+              op->orientation = COO::Right;
+              state.internalIndex = 8;
+              ACP_RULE(Type);
+            }
+
+            op->type = type;
+            op->orientation = orient;
+
+            // if we got here, it means it's an unary operator and we need `this`
+            if (!expectKeyword("this")) ACP_NOT_OK;
+            state.internalIndex = 3;
+            ACP_RULE(NullRule);
+          } else if (state.internalIndex == 3) {
+            if (ALTACORE_ANY_CAST<bool>(state.internalValue)) {
+              if (!expect(TokenType::ClosingParenthesis)) ACP_NOT_OK;
+            }
+
+            if (!expect(TokenType::Colon)) ACP_NOT_OK;
+            state.internalIndex = 4;
+            ACP_RULE(Type);
+          } else if (state.internalIndex == 4) {
+            if (!exps.back()) ACP_NOT_OK;
+
+            auto op = std::dynamic_pointer_cast<AST::ClassOperatorDefinitionStatement>(ruleNode);
+
+            op->returnType = std::dynamic_pointer_cast<AST::Type>(*exps.back().item);
+
+            state.internalIndex = 5;
+            ACP_RULE(Block);
+          } else if (state.internalIndex == 5) {
+            if (!exps.back()) ACP_NOT_OK;
+
+            auto op = std::dynamic_pointer_cast<AST::ClassOperatorDefinitionStatement>(ruleNode);
+
+            op->block = std::dynamic_pointer_cast<AST::BlockNode>(*exps.back().item);
+
+            ACP_NODE(op);
+          } else if (state.internalIndex == 6 || state.internalIndex == 7) {
+            using COT = AST::ClassOperatorType;
+            COT type = COT::NONE;
+            saveState();
+            if (expect(TokenType::PlusSign)) {
+              type = COT::Addition;
+            } else if (expect(TokenType::MinusSign)) {
+              type = COT::Subtraction;
+            } else if (expect(TokenType::Asterisk)) {
+              type = COT::Multiplication;
+            } else if (expect(TokenType::ForwardSlash)) {
+              type = COT::Division;
+            } else if (expect(TokenType::Caret)) {
+              type = COT::Xor;
+            } else if (expect(TokenType::LeftShift)) {
+              type = COT::LeftShift;
+            } else if (expect(TokenType::ClosingAngleBracket)) {
+              if (expect(TokenType::ClosingAngleBracket)) {
+                type = COT::RightShift;
+              } else {
+                type = COT::GreaterThan;
+              }
+            } else if (expect(TokenType::Ampersand)) {
+              type = COT::BitAnd;
+            } else if (expect(TokenType::Pipe)) {
+              type = COT::BitOr;
+            } else if (expect(TokenType::Or)) {
+              type = COT::Or;
+            } else if (expect(TokenType::And)) {
+              type = COT::And;
+            } else if (expect(TokenType::Equality)) {
+              type = COT::Equality;
+            } else if (expect(TokenType::Inequality)) {
+              type = COT::Inequality;
+            } else if (expect(TokenType::OpeningAngleBracket)) {
+              type = COT::LessThan;
+            } else if (expect(TokenType::LessThanOrEqualTo)) {
+              type = COT::LessThanOrEqualTo;
+            } else if (expect(TokenType::GreaterThanOrEqualTo)) {
+              type = COT::GreaterThanOrEqualTo;
+            } else if (expect(TokenType::Tilde)) {
+              type = COT::BitNot;
+            }
+
+            if (type == COT::NONE) ACP_NOT_OK;
+
+            auto op = std::dynamic_pointer_cast<AST::ClassOperatorDefinitionStatement>(ruleNode);
+
+            op->type = type;
+
+            if (state.internalIndex == 6) {
+              state.internalIndex = 9;
+              ACP_RULE(Type);
+            } else {
+              if (!expectKeyword("this")) ACP_NOT_OK;
+              state.internalIndex = 3;
+              ACP_RULE(NullRule);
+            }
+          } else if (state.internalIndex == 8 || state.internalIndex == 9) {
+            if (!exps.back()) ACP_NOT_OK;
+
+            auto op = std::dynamic_pointer_cast<AST::ClassOperatorDefinitionStatement>(ruleNode);
+
+            op->argumentType = std::dynamic_pointer_cast<AST::Type>(*exps.back().item);
+
+            if (state.internalIndex == 8) {
+              state.internalIndex = 7;
+              ACP_RULE(NullRule);
+            } else {
+              state.internalIndex = 3;
+              ACP_RULE(NullRule);
+            }
+          } else if (state.internalIndex == 10) {
+            if (!exps.back()) ACP_NOT_OK;
+
+            if (!expect(TokenType::ClosingSquareBracket)) ACP_NOT_OK;
+
+            state.internalIndex = 3;
+            ACP_RULE(NullRule);
+          }
         }
 
         next();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3451,6 +3451,8 @@ namespace AltaCore {
               type = COT::Dereference;
             } else if (expect(TokenType::Ampersand)) {
               type = COT::Reference;
+            } else if (expect(TokenType::Tilde)) {
+              type = COT::BitNot;
             } else if (expectKeyword("this")) {
               if (expect(TokenType::OpeningSquareBracket)) {
                 state.internalIndex = 10;
@@ -3539,8 +3541,6 @@ namespace AltaCore {
               type = COT::LessThanOrEqualTo;
             } else if (expect(TokenType::GreaterThanOrEqualTo)) {
               type = COT::GreaterThanOrEqualTo;
-            } else if (expect(TokenType::Tilde)) {
-              type = COT::BitNot;
             }
 
             if (type == COT::NONE) ACP_NOT_OK;


### PR DESCRIPTION
This PR adds a great feature aimed at increasing the simplicity of Alta code by allowing operators to be overloaded. Every operator can be overloaded, **except** the plain assignment operator (`=`) and the pre- and post- increment and decrement operators (`++`, `--`). Plain assignment not being overloadable is a design choice: assignment shouldn't have an tricks up its sleeves, it should always work the way you expect it to. The pre- and post- increment and decrement operators not being overloadable is simply because they weren't implemented.

Certain smaller features have also been slipped in here, such as the ability for special fetches to refer to special variables with identifiers (such as `$left` or `$right`) and always hoisting scope items used in accessors, as well as the fact that now constructors are hoisted.

In addition, this PR also contains a few general bug fixes, such as a typo fix for finding `from` casts and another typo fix in the parser which now allows bitwise XOR assignment to be used, and an infinite loop elimination when trying find casts for reference types.